### PR TITLE
Update compatibility rule to wrap the Then and Else clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Documentation of release versions of `nacc-form-validator`
 
 ## 0.2.0
 
-* Fixes bug with nested `logic` inside `compatibility` rules
+* Updates `_validate_compatibility` to iterate on multiple fields for `then` and `else` clauses, similar to how the `if` clause was handling it
 * Updates `cast_record` to set any missing fields to `None`
 * Updates `pants_version` in `pants.toml` to `2.22.0` (latest) to support building on macOS
 * Renamed `validator` to `nacc_form_validator` for a more unique namespace, and imported `QualityCheck` into `__init__.py` for easier access

--- a/docs/data-quality-rule-definition-guidelines.md
+++ b/docs/data-quality-rule-definition-guidelines.md
@@ -344,9 +344,9 @@ birthyr:
 
 ### compatibility
 
-Used to specify the list of compatibility (if-then) constraints for a given field with other fields within the form or across multiple forms. A field will only pass validation if none of the compatibility constraints are violated.
+Used to specify the list of compatibility (if-then-else) constraints for a given field with other fields within the form or across multiple forms. A field will only pass validation if none of the compatibility constraints are violated.
 
-Each constraint specifies `if` and `then` attributes to allow the application of a subschema based on the outcome of another schema (i.e. when the schema defined under `if` evaluates to true for a given record, then the schema specified under `then` will be evaluated).
+Each constraint specifies `if`, `then`, and (optionally) `else` attributes to allow the validation of a set of fields/subschemas based on the outcome of other fields/subschemas (i.e. when the schema(s) defined under `if` evaluates to true for a given record, then the schema(s) specified under `then` will be evaluated). Each `if/then/else` attribute can have several fields which need to be satisifed, with the `*_op` attribute specifying the boolean operation in which to compare the different fields. For example, if `if_op = or`, then as long as _any_ of the fields satsify their schema, the `then` attribute will be evaluated. The default `*_op` is `and`.
 
 The rule definition for `compatibility` follows the following format:
 
@@ -356,18 +356,28 @@ The rule definition for `compatibility` follows the following format:
         "compatibility": [
             {
                 "if": {
-                    "subschema_attribute": "subschema to be satisifed for other fields"
+                    "<field_name>": "subschema to be satisifed"
                 },
                 "then": {
-                    "subschema_attribute": "conditions to be satisifed for the current field"
+                    "<field_name>": "subschema to be satisifed"
                 }
             },
             {
+                "if_op": "and",
+                "then_op": "or",
+                "else_op": "or",
+
                 "if": {
-                    "subschema_attribute": "subschema to be satisifed for other fields"
+                    "<field_name>": "subschema to be satisifed",
+                    "<field_name>": "subschema to be satisifed"
                 },
                 "then": {
-                    "subschema_attribute": "conditions to be satisifed for the current field"
+                    "<field_name>": "subschema to be satisifed",
+                    "<field_name>": "subschema to be satisifed"
+                },
+                "else": {
+                    "<field_name>": "subschema to be satisifed",
+                    "<field_name>": "subschema to be satisifed"
                 }
             }
         ]

--- a/nacc_form_validator/errors.py
+++ b/nacc_form_validator/errors.py
@@ -112,6 +112,9 @@ class SchemaDefs:
 
     TYPE = "type"
     OP = "op"
+    IF_OP = 'if_op'
+    THEN_OP = 'then_op'
+    ELSE_OP = 'else_op'
     IF = "if"
     THEN = "then"
     ELSE = "else"

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -415,11 +415,11 @@ class NACCValidator(Validator):
         elif filled and value is None:
             self._error(field, ErrorDefs.FILLED_TRUE)
 
-    def _check_subschema_valid(self, all_conditions: Dict[str, object], operator: str) -> Tuple[bool, Dict[str, object]]:
+    def _check_subschema_valid(self, all_conditions: Dict[str, object], operator: str) -> Tuple[bool, object]:
         """ Helper method for _validate_compatibility, creates a temporary validator and
             checks a subschema against it """
         valid = operator != "OR"
-        errors = {}
+        errors = None
 
         for field, conds in all_conditions.items():
             subschema = {field: conds}
@@ -436,13 +436,13 @@ class NACCValidator(Validator):
                 if valid:
                     break
                 elif not errors:  # just keep track of first one that failed
-                    errors.update(temp_validator.errors.items())
+                    errors = temp_validator.errors.items()
 
             # Evaluate as logical AND operation
             elif not temp_validator.validate(self.document,
                                              normalize=False):
                 valid = False
-                errors.update(temp_validator.errors.items())
+                errors = temp_validator.errors.items()
                 break
 
         if valid:  # in the OR case, if something passed we can ignore other errors
@@ -522,7 +522,6 @@ class NACCValidator(Validator):
             # If there are errors, something in the then/else clause failed - report them
             if errors:
                 for error in errors:
-                    raise ValueError(str(errors))
                     self._error(field, error_def, rule_no, str(error),
                                 if_conds)
 

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -3,7 +3,7 @@ library)."""
 
 import logging
 from datetime import datetime as dt
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from cerberus.validator import Validator
 from dateutil import parser
@@ -415,6 +415,41 @@ class NACCValidator(Validator):
         elif filled and value is None:
             self._error(field, ErrorDefs.FILLED_TRUE)
 
+    def _check_subschema_valid(self, all_conditions: Dict[str, object], operator: str) -> Tuple[bool, Dict[str, object]]:
+        """ Helper method for _validate_compatibility, creates a temporary validator and
+            checks a subschema against it """
+        valid = operator != "OR"
+        errors = {}
+
+        for field, conds in all_conditions.items():
+            subschema = {field: conds}
+
+            temp_validator = NACCValidator(
+                subschema,
+                allow_unknown=True,
+                error_handler=CustomErrorHandler(subschema),
+            )
+            if operator == "OR":
+                valid = valid or temp_validator.validate(self.document,
+                                                         normalize=False)
+                # if something passed, don't need to evaluate rest
+                if valid:
+                    break
+                elif not errors:  # just keep track of first one that failed
+                    errors.update(temp_validator.errors.items())
+
+            # Evaluate as logical AND operation
+            elif not temp_validator.validate(self.document,
+                                             normalize=False):
+                valid = False
+                errors.update(temp_validator.errors.items())
+                break
+
+        if valid:  # in the OR case, if something passed we can ignore other errors
+            errors = None
+
+        return valid, errors
+
     # pylint: disable=(too-many-locals, unused-argument)
     def _validate_compatibility(self, constraints: List[Mapping], field: str,
                                 value: object):
@@ -435,7 +470,9 @@ class NACCValidator(Validator):
                     'type': 'dict',
                     'schema': {
                         'index': {'type': 'integer', 'required': False},
-                        'op': {'type': 'string', 'required': False, 'allowed': ['AND', 'OR', 'and', 'or']},
+                        'if_op': {'type': 'string', 'required': False, 'allowed': ['AND', 'OR', 'and', 'or']},
+                        'then_op': {'type': 'string', 'required': False, 'allowed': ['AND', 'OR', 'and', 'or']},
+                        'else_op': {'type': 'string', 'required': False, 'allowed': ['AND', 'OR', 'and', 'or']},
                         'if': {'type': 'dict', 'required': True, 'empty': False},
                         'then': {'type': 'dict', 'required': True, 'empty': False},
                         'else': {'type': 'dict', 'required': False, 'empty': False}
@@ -448,8 +485,10 @@ class NACCValidator(Validator):
         # validation fails if any of the constraints fails.
         rule_no = 0
         for constraint in constraints:
-            # Extract operator if specified, default is AND
-            operator = constraint.get(SchemaDefs.OP, "AND").upper()
+            # Extract operators if specified, default is AND
+            if_operator = constraint.get(SchemaDefs.IF_OP, "AND").upper()
+            then_operator = constraint.get(SchemaDefs.THEN_OP, "AND").upper()
+            else_operator = constraint.get(SchemaDefs.ELSE_OP, "AND").upper()
 
             # Extract constraint index if specified, or increment by 1
             rule_no = constraint.get(SchemaDefs.INDEX, rule_no + 1)
@@ -463,46 +502,29 @@ class NACCValidator(Validator):
             # Extract conditions for else clause, this is optional
             else_conds = constraint.get(SchemaDefs.ELSE, None)
 
-            valid = operator != "OR"
-            # Check whether the dependency conditions satisfied
-            for dep_field, conds in if_conds.items():
-                subschema = {dep_field: conds}
+            # Check if dependencies satisfied the If clause
+            error_def = ErrorDefs.COMPATIBILITY_FALSE
+            errors = None
+            valid, _ = self._check_subschema_valid(if_conds, if_operator)
 
-                temp_validator = NACCValidator(
-                    subschema,
-                    allow_unknown=True,
-                    error_handler=CustomErrorHandler(subschema),
-                )
-                if operator == "OR":
-                    valid = valid or temp_validator.validate(self.document,
-                                                             normalize=False)
-                # Evaluate as logical AND operation
-                elif not temp_validator.validate(self.document,
-                                                 normalize=False):
-                    valid = False
-                    break
-
-            subschema = None
-            # If dependencies satisfied validate Then clause
+            # If the If clause valid, validate the Then clause
             if valid:
-                subschema = {field: then_conds}
+                valid, errors = self._check_subschema_valid(then_conds, then_operator)
                 error_def = ErrorDefs.COMPATIBILITY_TRUE
-            # If dependencies not satisfied validate Else clause
-            elif else_conds:
-                subschema = {field: else_conds}
-                error_def = ErrorDefs.COMPATIBILITY_FALSE
 
-            if subschema:
-                temp_validator = NACCValidator(
-                    subschema,
-                    allow_unknown=True,
-                    error_handler=CustomErrorHandler(subschema),
-                )
-                if not temp_validator.validate(self.document, normalize=False):
-                    errors = temp_validator.errors.items()
-                    for error in errors:
-                        self._error(field, error_def, rule_no, str(error),
-                                    if_conds)
+            # Otherwise validate the else clause, if they exist
+            elif else_conds:
+                valid, errors = self._check_subschema_valid(else_conds, else_operator)
+                error_def = ErrorDefs.COMPATIBILITY_FALSE
+            else:  # if the If condition is not satisfied, do nothing
+                pass
+
+            # If there are errors, something in the then/else clause failed - report them
+            if errors:
+                for error in errors:
+                    raise ValueError(str(errors))
+                    self._error(field, error_def, rule_no, str(error),
+                                if_conds)
 
     # pylint: disable=(too-many-locals)
     def _validate_temporalrules(self, temporalrules: Dict[str, Any],

--- a/tests/test_nacc_validator.py
+++ b/tests/test_nacc_validator.py
@@ -181,18 +181,18 @@ def test_anyof():
     """ Test anyof case """
     schema = {
         "dummy_var": {
-                "type": "integer",
-                "required": True,
-                "anyof": [
-                    {
-                        "min": 0,
-                        "max": 10
-                    },
-                    {
-                        "allowed": [99]
-                    }
-                ]
-            }
+            "type": "integer",
+            "required": True,
+            "anyof": [
+                {
+                    "min": 0,
+                    "max": 10
+                },
+                {
+                    "allowed": [99]
+                }
+            ]
+        }
     }
     nv = create_nacc_validator(schema)
 
@@ -243,23 +243,18 @@ def test_compatibility_if_then(nv):
             "compatibility": [
                 {
                     "if": {
-                        "mode": {
-                            "allowed": [2]
-                        }
+                        "mode": {"allowed": [2]}
                     },
                     "then": {
-                        "nullable": False
+                        "rmreason": {"nullable": False}
                     }
                 },
                 {
                     "if": {
-                        "mode": {
-                            "allowed": [1, 3]
-                        }
+                        "mode": {"allowed": [1, 3]}
                     },
                     "then": {
-                        "nullable": True,
-                        "filled": False
+                        "rmreason": {"nullable": True, "filled": False}
                     }
                 }
             ],
@@ -409,8 +404,7 @@ def test_compatibility_with_nested_logic_or():
                         }
                     },
                     "then": {
-                        "nullable": True,
-                        "filled": False
+                        "raceunkn": {"nullable": True, "filled": False}
                     }
                 }
             ]
@@ -449,14 +443,18 @@ def test_multiple_compatibility():
                     "if": {
                         "enrlgenoth": {"allowed": [1]}
                     },
-                    "then": {"nullable": False}
+                    "then": {
+                        "enrlgenothx": {"nullable": False}
+                    }
                 },
                 {
                     "index": 1,
                     "if": {
                         "enrlgenoth": {"nullable": True, "filled": False}
                     },
-                    "then": {"nullable": True, "filled": False}
+                    "then": {
+                        "enrlgenothx": {"nullable": True, "filled": False}
+                    }
                 }
             ]
         }
@@ -499,8 +497,7 @@ def test_compatibility_multiple_variables_and():
                         "otherdep": {"allowed": [0, 2, 9]}
                     },
                     "then": {
-                        "nullable": True,
-                        "filled": False
+                        "deprtreat": {"nullable": True,"filled": False}
                     }
                 }
             ]
@@ -542,7 +539,7 @@ def test_compatibility_multiple_variables_or():
                         "otherdep": {"allowed": [1]}
                     },
                     "then": {
-                        "nullable": False,
+                        "deprtreat": {"nullable": False}
                     }
                 }
             ]
@@ -583,20 +580,19 @@ def test_compatibility_then_multiple_blank_and():
             "compatibility": [
                 {
                     "if": {
-                        "parentvar": {
-                            "nullable": True,
-                            "filled": False
-                        }
+                        "parentvar": {"nullable": True,"filled": False}
                     },
                     "then": {
-                        "nullable": True,  # this is specifically required in schema for the None case
-                        "logic": {
-                            "formula": {
-                                "and": [
-                                    {"==": [None, {"var": "var1"}]},
-                                    {"==": [None, {"var": "var2"}]},
-                                    {"==": [None, {"var": "var3"}]}
-                                ]
+                        "var1": {
+                            "nullable": True,  # this is specifically required in schema for the None case
+                            "logic": {
+                                "formula": {
+                                    "and": [
+                                        {"==": [None, {"var": "var1"}]},
+                                        {"==": [None, {"var": "var2"}]},
+                                        {"==": [None, {"var": "var3"}]}
+                                    ]
+                                }
                             }
                         }
                     }
@@ -638,21 +634,21 @@ def test_compatibility_multiple_resulting_variables_or():
                 {
                     "op": "or",
                     "if": {
-                        "bevhall": {"allowed": [1]},
-                        "beahall": {"allowed": [1]}
+                        "hall": {"allowed": [1]}
                     },
                     "then": {
-                        "allowed": [1]
+                        "bevhall": {"allowed": [1]},
+                        "beahall": {"allowed": [1]}
                     }
                 },
                 {
                     "op": "and",
                     "if": {
-                        "bevhall": {"allowed": [0]},
-                        "beahall": {"allowed": [0]}
+                        "hall": {"allowed": [0]}
                     },
                     "then": {
-                        "allowed": [0]
+                        "bevhall": {"allowed": [0]},
+                        "beahall": {"allowed": [0]}
                     }
                 }                
             ]
@@ -691,11 +687,11 @@ def test_compatibility_multiple_resulting_options_or():
                 {
                     "op": "and",
                     "if": {
-                        "majdepdx": {"allowed": [0, 2]},
-                        "othdepdx": {"allowed": [0, 2]},
+                        "depd": {"allowed": [1]}
                     },
                     "then": {
-                        "allowed": [1]
+                        "majdepdx": {"allowed": [0, 2]},
+                        "othdepdx": {"allowed": [0, 2]}
                     }
                 }
             ]
@@ -715,6 +711,76 @@ def test_compatibility_multiple_resulting_options_or():
     assert nv.errors == {'depd': ["('depd', ['unallowed value 2']) for {'majdepdx': {'allowed': [0, 2]}, 'othdepdx': {'allowed': [0, 2]}} - compatibility rule no: 1"]}
     assert not nv.validate({"depd": None, "majdepdx": 0, "othdepdx": 2})
     assert nv.errors == {'depd': ["('depd', ['null value not allowed']) for {'majdepdx': {'allowed': [0, 2]}, 'othdepdx': {'allowed': [0, 2]}} - compatibility rule no: 1", 'null value not allowed']}
+
+def test_compatibility_nested_anyof():
+    """ Tests when anyof is nested inside compatibility. """
+    schema = {
+        "menarche": {
+            "nullable": True,
+            "type": "integer",
+            "anyof": [
+                {"min": 5, "max": 25},
+                {"allowed": [88,99]}
+            ]
+        },
+        "nomensage": {
+            "nullable": True,
+            "type": "integer",
+            "compatibility": [
+                {
+                    "index": 0,
+                    "if": {
+                        "menarche": {
+                            "anyof": [
+                                {"min": 5, "max": 25},
+                                {"allowed": [99]}
+                            ]
+                        }
+                    },
+                    "then": {
+                        "nomensage": {"nullable": False}
+                    }
+                },
+                {
+                    "index": 1,
+                    "if": {
+                        "menarche": {
+                            "nullable": True,
+                            "anyof": [
+                                {"nullable": True, "filled": False},
+                                {"allowed": [88]}
+                            ]
+                        }
+                    },
+                    "then": {
+                        "nomensage": {"nullable": True, "filled": False}
+                    }
+                }
+            ],
+            "anyof": [
+                {"min": 10,"max": 70},
+                {"allowed": [88,99]}
+            ]
+        }
+    }
+    nv = create_nacc_validator(schema)
+
+    for i in range (5, 26):
+        assert nv.validate({"menarche": i, "nomensage": 20})
+    assert nv.validate({"menarche": 99, "nomensage": 99})
+    assert nv.validate({"menarche": None, "nomensage": None})
+    assert nv.validate({"menarche": 88, "nomensage": None})
+
+    for i in range (5, 26):
+        assert not nv.validate({"menarche": 5, "nomensage": None})
+    assert nv.errors == {'nomensage': ["('nomensage', ['null value not allowed']) for {'menarche': {'anyof': [{'min': 5, 'max': 25}, {'allowed': [99]}]}} - compatibility rule no: 0"]}
+    assert not nv.validate({"menarche": 99, "nomensage": None})
+    assert nv.errors == {'nomensage': ["('nomensage', ['null value not allowed']) for {'menarche': {'anyof': [{'min': 5, 'max': 25}, {'allowed': [99]}]}} - compatibility rule no: 0"]}
+    assert not nv.validate({"menarche": 88, "nomensage": 10})
+    assert nv.errors == {'nomensage': ["('nomensage', ['must be empty']) for {'menarche': {'nullable': True, 'anyof': [{'nullable': True, 'filled': False}, {'allowed': [88]}]}} - compatibility rule no: 1"]}
+    assert not nv.validate({"menarche": None, "nomensage": 10})
+    assert nv.errors == {'nomensage': ["('nomensage', ['must be empty']) for {'menarche': {'nullable': True, 'anyof': [{'nullable': True, 'filled': False}, {'allowed': [88]}]}} - compatibility rule no: 1"]}
+
 
 def test_compare_with_current_year():
     """ Test compare_with operator, both with an adjustment and without; and with special key current_year """
@@ -783,20 +849,20 @@ def test_lots_of_rules():
                 {
                     "index": 0,
                     "if": {
-                        "prevenrl": {
-                            "allowed": [1]
-                        }
+                        "prevenrl": {"allowed": [1]}
                     },
-                    "then": {"nullable": False}
+                    "then": {
+                        "oldadcid": {"nullable": False}
+                    }
                 },
                 {
                     "index": 1,
                     "if": {
-                        "prevenrl": {
-                            "allowed": [0, 9]
-                        }
+                        "prevenrl": {"allowed": [0, 9]}
                     },
-                    "then": {"nullable": True, "filled": False}
+                    "then": {
+                        "oldadcid": {"nullable": True, "filled": False}
+                    }
                 }
             ],
             "logic": {

--- a/tests/test_nacc_validator.py
+++ b/tests/test_nacc_validator.py
@@ -533,7 +533,7 @@ def test_compatibility_multiple_variables_or():
             "allowed": [0, 1],
             "compatibility": [
                 {
-                    "op": "OR",
+                    "if_op": "OR",
                     "if": {
                         "majordep": {"allowed": [1]},
                         "otherdep": {"allowed": [1]}
@@ -632,7 +632,7 @@ def test_compatibility_multiple_resulting_variables_or():
             "required": True,
             "compatibility": [
                 {
-                    "op": "or",
+                    "then_op": "or",
                     "if": {
                         "hall": {"allowed": [1]}
                     },
@@ -642,7 +642,7 @@ def test_compatibility_multiple_resulting_variables_or():
                     }
                 },
                 {
-                    "op": "and",
+                    "then_op": "and",
                     "if": {
                         "hall": {"allowed": [0]}
                     },
@@ -659,15 +659,16 @@ def test_compatibility_multiple_resulting_variables_or():
     assert nv.validate({"hall": 1, "bevhall": 1, "beahall": 0})
     assert nv.validate({"hall": 1, "bevhall": 0, "beahall": 1})
     assert nv.validate({"hall": 1, "bevhall": 1, "beahall": 1})
-    assert nv.validate({"hall": 0, "bevhall": None, "beahall": None})
     assert nv.validate({"hall": 5, "bevhall": 3, "beahall": 3})
-    assert nv.validate({"hall": 1, "bevhall": None, "beahall": None})
+    assert nv.validate({"hall": 1, "bevhall": 1, "beahall": None})
     assert nv.validate({"hall": 0, "bevhall": 0, "beahall": 0})
 
     assert not nv.validate({"hall": 1, "bevhall": 0, "beahall": 0})
-    assert nv.errors == {'hall': ["('hall', ['unallowed value 1']) for {'bevhall': {'allowed': [0]}, 'beahall': {'allowed': [0]}} - compatibility rule no: 2"]}
+    assert nv.errors == {'hall': ["('bevhall', ['unallowed value 0']) for {'hall': {'allowed': [1]}} - compatibility rule no: 1"]}
     assert not nv.validate({"hall": 0, "bevhall": 0, "beahall": 1})
-    assert nv.errors == {'hall': ["('hall', ['unallowed value 0']) for {'bevhall': {'allowed': [1]}, 'beahall': {'allowed': [1]}} - compatibility rule no: 1"]}
+    assert nv.errors == {'hall': ["('beahall', ['unallowed value 1']) for {'hall': {'allowed': [0]}} - compatibility rule no: 2"]}
+    assert not nv.validate({"hall": 0, "bevhall": None, "beahall": None})
+    assert nv.errors == {'hall': ["('bevhall', ['null value not allowed']) for {'hall': {'allowed': [0]}} - compatibility rule no: 2"]}
 
 def test_compatibility_multiple_resulting_options_or():
     """ Tests a "If X is 1, than Y and Z should be 0 or 2" situation """
@@ -685,13 +686,23 @@ def test_compatibility_multiple_resulting_options_or():
             "required": True,
             "compatibility": [
                 {
-                    "op": "and",
+                    "index": 0,
                     "if": {
                         "depd": {"allowed": [1]}
                     },
                     "then": {
                         "majdepdx": {"allowed": [0, 2]},
                         "othdepdx": {"allowed": [0, 2]}
+                    }
+                },
+                {
+                    "index": 2,
+                    "if": {
+                        "depd": {"allowed": [2]}
+                    },
+                    "then": {
+                        "majdepdx": {"allowed": [1]},
+                        "othdepdx": {"allowed": [1]}
                     }
                 }
             ]
@@ -708,9 +719,9 @@ def test_compatibility_multiple_resulting_options_or():
     assert nv.validate({"depd": 5, "majdepdx": 1, "othdepdx": 1})
 
     assert not nv.validate({"depd": 2, "majdepdx": 0, "othdepdx": 2})
-    assert nv.errors == {'depd': ["('depd', ['unallowed value 2']) for {'majdepdx': {'allowed': [0, 2]}, 'othdepdx': {'allowed': [0, 2]}} - compatibility rule no: 1"]}
+    assert nv.errors == {'depd': ["('majdepdx', ['unallowed value 0']) for {'depd': {'allowed': [2]}} - compatibility rule no: 2"]}
     assert not nv.validate({"depd": None, "majdepdx": 0, "othdepdx": 2})
-    assert nv.errors == {'depd': ["('depd', ['null value not allowed']) for {'majdepdx': {'allowed': [0, 2]}, 'othdepdx': {'allowed': [0, 2]}} - compatibility rule no: 1", 'null value not allowed']}
+    assert nv.errors == {'depd': ['null value not allowed']}
 
 def test_compatibility_nested_anyof():
     """ Tests when anyof is nested inside compatibility. """

--- a/tests/test_nacc_validator.py
+++ b/tests/test_nacc_validator.py
@@ -397,7 +397,7 @@ def test_compatibility_with_nested_logic_or():
                                     "or": [
                                         {"==": [1, {"var": "raceaian"}]},
                                         {"==": [1, {"var": "raceasian"}]},
-                                        {"==": [1, {"var": "raceblack"}]},
+                                        {"==": [1, {"var": "raceblack"}]}
                                     ]
                                 }
                             }

--- a/tests/test_nacc_validator.py
+++ b/tests/test_nacc_validator.py
@@ -497,7 +497,7 @@ def test_compatibility_multiple_variables_and():
                         "otherdep": {"allowed": [0, 2, 9]}
                     },
                     "then": {
-                        "deprtreat": {"nullable": True,"filled": False}
+                        "deprtreat": {"nullable": True, "filled": False}
                     }
                 }
             ]

--- a/tests/test_nacc_validator.py
+++ b/tests/test_nacc_validator.py
@@ -391,13 +391,13 @@ def test_compatibility_with_nested_logic_or():
             "compatibility": [
                 {
                     "if": {
-                        "raceunkn": {
+                        "raceaian": {
                             "logic": {
                                 "formula": {
                                     "or": [
                                         {"==": [1, {"var": "raceaian"}]},
                                         {"==": [1, {"var": "raceasian"}]},
-                                        {"==": [1, {"var": "raceblack"}]}
+                                        {"==": [1, {"var": "raceblack"}]},
                                     ]
                                 }
                             }
@@ -418,13 +418,16 @@ def test_compatibility_with_nested_logic_or():
     assert nv.validate({'raceaian': 1})
     assert nv.validate({'raceasian': 1})
     assert nv.validate({'raceblack': 1})
-    assert nv.validate({'raceunkn': 1})
     assert nv.validate({'raceunkn': 1, 'raceaian': None, 'raceasian': None, 'raceblack': None})
     assert nv.validate({'raceaian': 1, 'raceasian': 1, 'raceblack': 1})
 
     # the compatibility if/then with logic inside means that raceunkn cannot be 1 if any of the others are set
     assert not nv.validate({'raceaian': 1, 'raceunkn': 1})
-    assert nv.errors == {'raceunkn': ["('raceunkn', ['must be empty']) for {'raceunkn': {'logic': {'formula': {'or': [{'==': [1, {'var': 'raceaian'}]}, {'==': [1, {'var': 'raceasian'}]}, {'==': [1, {'var': 'raceblack'}]}]}}}} - compatibility rule no: 1"]}
+    assert nv.errors == {'raceunkn': ["('raceunkn', ['must be empty']) for {'raceaian': {'logic': {'formula': {'or': [{'==': [1, {'var': 'raceaian'}]}, {'==': [1, {'var': 'raceasian'}]}, {'==': [1, {'var': 'raceblack'}]}]}}}} - compatibility rule no: 1"]}
+    assert not nv.validate({'raceasian': 1, 'raceunkn': 1})
+    assert nv.errors == {'raceunkn': ["('raceunkn', ['must be empty']) for {'raceaian': {'logic': {'formula': {'or': [{'==': [1, {'var': 'raceaian'}]}, {'==': [1, {'var': 'raceasian'}]}, {'==': [1, {'var': 'raceblack'}]}]}}}} - compatibility rule no: 1"]}
+    assert not nv.validate({'raceblack': 1, 'raceunkn': 1})
+    assert nv.errors == {'raceunkn': ["('raceunkn', ['must be empty']) for {'raceaian': {'logic': {'formula': {'or': [{'==': [1, {'var': 'raceaian'}]}, {'==': [1, {'var': 'raceasian'}]}, {'==': [1, {'var': 'raceblack'}]}]}}}} - compatibility rule no: 1"]}
 
 def test_multiple_compatibility():
     """ Test multiple compatibility rules """


### PR DESCRIPTION
Updates the code to wrap the `then` and `else` clause for the `compatibility` rule, similar to how `if` was being handled. Also updates the tests/documentation to account for these changes.