### PR TITLE
Add rxnorm validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Documentation of release versions of `nacc-form-validator`
 * Fixed a bug in min/max validation wrt current_year
 * Updates `_validate_temporalrules` to iterate on multiple fields for `previous` and `current` clauses, remove `orderby` attribute
 * Change `_check_with_gds` function to `_validate_compute_gds` and update GDS score validation
+* Add `_check_with_rxnorm` function to check whether a given Drug ID is valid RXCUI code.
 
 ## 0.2.0
 

--- a/docs/data-quality-rule-definition-guidelines.md
+++ b/docs/data-quality-rule-definition-guidelines.md
@@ -12,6 +12,7 @@
     - [logic](#logic)
     - [temporalrules](#temporalrules)
     - [compute\_gds](#compute_gds)
+    - [rxnorm](#rxnorm)
 
 ## Introduction
 
@@ -673,9 +674,10 @@ var3:
 ### temporalrules
 
 Used to specify the list of checks to be performed against the previous visit for the same participant.
-
 * Each constraint specifies `previous` and `current` attributes. If conditions specified under `previous` subschema satisfied by the previous visit record, then the current visit record must satisfy the conditions specified under `current` subschema.
 * Each `previous/current` attribute can have several fields which need to be satisifed, with the `*_op` attribute specifying the boolean operation in which to compare the different fields. For example, if `prev_op = or`, then as long as _any_ of the fields satsify their schema, the `current` attribute will be evaluated. The default `*_op` is `and`.
+
+*To validate `temporalrules`, validator should have a `Datastore` instance which will be used to retrieve the previous visit record(s) for the participant.*
 
 The rule definition for `temporalrules` should follow the following format:
 
@@ -779,3 +781,18 @@ The rule definition for `compute_gds` should follow the following format:
     }
 }
 ```
+
+### rxnorm
+
+Custom rule defined to check whether a given Drug ID is valid RXCUI code.
+
+This function uses `check_with` rule from Cerberus. Rule definition should be in the following format:
+
+```json
+{
+    "<rxnormid variable>": {
+        "check_with": "rxnorm"
+    }
+}
+```
+*To validate `rxnorm`, validator should have a `Datastore` instance which implements `is_valid_rxcui` function which will check whether the given rxnormid value is valid RXCUI code*

--- a/nacc_form_validator/datastore.py
+++ b/nacc_form_validator/datastore.py
@@ -14,7 +14,8 @@ class Datastore(ABC):
     def __init__(self, pk_field: str, orderby: str):
         """
         Args:
-            pk_field: Primary key field to uniquely identify a participant
+            pk_field: primary key field to uniquely identify a participant
+            orderby: field to sort the records by
         """
         self.__pk_field = pk_field
         self.__orderby = orderby
@@ -51,3 +52,18 @@ class Datastore(ABC):
             Dict[str, str]: Previous record or None if no previous record found
         """
         return None
+
+    @abstractmethod
+    def is_valid_rxcui(self, drugid: int) -> bool:
+        """Abstract method to check whether a given drug ID is valid RXCUI.
+        Override this method to implement drug ID validation. Check
+        https://www.nlm.nih.gov/research/umls/rxnorm/overview.html,
+        https://mor.nlm.nih.gov/RxNav/
+
+        Args:
+            drugid: provided drug ID
+
+        Returns:
+            bool: True if provided drug ID is valid, else False
+        """
+        return False

--- a/nacc_form_validator/errors.py
+++ b/nacc_form_validator/errors.py
@@ -38,6 +38,7 @@ class ErrorDefs:
     CHECK_GDS_4 = ErrorDefinition(0x2007, "check_with")
     CHECK_GDS_5 = ErrorDefinition(0x2008, "check_with")
     COMPARE_WITH = ErrorDefinition(0x2009, "compare_with")
+    RXNORM = ErrorDefinition(0x3000, "check_with")
 
 
 class CustomErrorHandler(BasicErrorHandler):
@@ -88,6 +89,7 @@ class CustomErrorHandler(BasicErrorHandler):
             0x2007: "incorrect total GDS score {0}, expected value {1}",
             0x2008: "incorrect partial GDS score {0}, expected value {1}",
             0x2009: "input value doesn't satisfy the condition {0}",
+            0x3000: "Drug ID {0} is not a valid RXCUI"
         }
 
         self.messages.update(custom_errors)

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -543,8 +543,8 @@ class NACCValidator(Validator):
                                 if_conds)
 
     # pylint: disable=(too-many-locals)
-    def _validate_temporalrules(self, temporalrules: List[Mapping],
-                                field: str, value: object):
+    def _validate_temporalrules(self, temporalrules: List[Mapping], field: str,
+                                value: object):
         """Validate the List of longitudial checks specified for a field.
 
         Args:
@@ -849,3 +849,25 @@ class NACCValidator(Validator):
                 self._error(field, ErrorDefs.COMPARE_WITH, comparison_str)
         except TypeError:
             self._error(field, ErrorDefs.COMPARE_WITH, comparison_str)
+
+    def _check_with_rxnorm(self, field: str, value: Optional[int]):
+        """Check whether the specified value is a valid RXCUI
+        https://www.nlm.nih.gov/research/umls/rxnorm/overview.html
+        https://mor.nlm.nih.gov/RxNav/
+
+        Args:
+            field: Variable name
+            value: Variable value
+        """
+
+        # No need to validate if blank or 0 (No RXCUI code available)
+        if not value or value == 0:
+            return
+
+        if not self.datastore:
+            err_msg = "Datastore not set, cannot validate RXNORM codes"
+            self.__add_system_error(field, err_msg)
+            raise ValidationException(err_msg)
+
+        if not self.datastore.is_valid_rxcui(value):
+            self._error(field, ErrorDefs.RXNORM, value)


### PR DESCRIPTION
Add _check_with_rxnorm function to check whether a given Drug ID is valid RXCUI code.
Add is_valid_rxcui() function abstract method to Datastore class, need to override this method in form-qc-checker gear to implement drug ID validation.

I'll update the documentation once other pending PRs are merged.
Adding all of these new functions under version 3.0.0 as we didn't made a release yet.