### PR TITLE
Add count_exact operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Documentation of release versions of `nacc-form-validator`
 * Adds `previous_record` as a special keyword for `compare_with`
 * Adds `get_previous_record` method to grab previous record from Datastore, which can grab the previous record or the previous record where a specific field is non-empty
 * Adds new rule `compare_with_date` to handle rules that need to compare dates (or ages relative to dates)
+* Adds custum operator `count_exact` to `json_logic.py`
 
 ## 0.3.0
 

--- a/docs/data-quality-rule-definition-guidelines.md
+++ b/docs/data-quality-rule-definition-guidelines.md
@@ -758,12 +758,6 @@ The rule definition for `logic` should follow the following format:
 }
 ```
 
-The validator also has a custom operator in addition to the ones provided by json-logic-py:
-
-| Operator | Arguments | Description |
-| -------- | --------- | ----------- |
-| `count_exact` | `[base, var1, var2, var3, ...]` | Counts how many values in the list equal the base. The first value is alwyas considered the base, and the rest of the list is compared to it, so this operator requires at least 2 items. |
-
 **Example:**
 
 One of `var1`, `var2`, or `var3` must be `1`.
@@ -843,6 +837,16 @@ var3:
 ```
 </td>
 </table>
+
+#### Custom Operations
+
+The validator also has custom operators in addition to the ones provided by json-logic-py:
+
+| Operator | Arguments | Description |
+| -------- | --------- | ----------- |
+| `count` | `[var1, var2, var3...]` | Counts how many valid variables are in the list, ignoring null and 0 values |
+| `count_exact` | `[base, var1, var2, var3, ...]` | Counts how many values in the list equal the base. The first value is alwyas considered the base, and the rest of the list is compared to it, so this operator requires at least 2 items. |
+
 
 ### temporalrules
 

--- a/docs/data-quality-rule-definition-guidelines.md
+++ b/docs/data-quality-rule-definition-guidelines.md
@@ -758,6 +758,12 @@ The rule definition for `logic` should follow the following format:
 }
 ```
 
+The validator also has a custom operator in addition to the ones provided by json-logic-py:
+
+| Operator | Arguments | Description |
+| -------- | --------- | ----------- |
+| `count_exact` | `[base, var1, var2, var3, ...]` | Counts how many values in the list equal the base. The first value is alwyas considered the base, and the rest of the list is compared to it, so this operator requires at least 2 items. |
+
 **Example:**
 
 One of `var1`, `var2`, or `var3` must be `1`.

--- a/nacc_form_validator/json_logic.py
+++ b/nacc_form_validator/json_logic.py
@@ -165,6 +165,14 @@ def missing_some(data, args, min_required=1):
     return ret
 
 
+def count_exact(args):
+    if len(args) < 2:
+        raise ValueError("count_exact needs a base and at least 1 value to compare to")
+
+    base = args[0]
+    return sum([1 for x in args[1:] if x == base])
+
+
 operations = {
     "==": soft_equals,
     "===": hard_equals,
@@ -192,6 +200,7 @@ operations = {
     "max": lambda *args: max(args),
     "merge": merge,
     "count": lambda *args: sum(1 if a else 0 for a in args),
+    "count_exact": lambda *args: count_exact(args)
 }
 
 

--- a/tests/test_rules_logic.py
+++ b/tests/test_rules_logic.py
@@ -1,5 +1,5 @@
 """
-Tests the custom logic rule (_validate_logic).
+Tests the custom logic rule (_validate_logic) which uses json_logic.py.
 """
 def test_logic_or(create_nacc_validator):
     """ Test mathematical logic or case """
@@ -163,3 +163,83 @@ def test_logic_sum(create_nacc_validator):
 
     assert not nv.validate({"total": 9, "var1": 5, "var2": 3, "var3": 2})
     assert nv.errors == {'total': ['error in formula evaluation - value 9 does not satisfy the specified formula']}
+
+def test_logic_count_exact(create_nacc_validator):
+    """ Test the count_exact logic rule, which counts how many values in a list equal the base
+        Also ensures blanks are ignored in the count """
+    schema = {
+        "var1": {"type": "integer", "nullable": True},
+        "var2": {"type": "integer", "nullable": True},
+        "var3": {"type": "integer", "nullable": True},
+        "var4": {"type": "integer", "nullable": True},
+        "var5": {"type": "integer", "nullable": True},
+        "count": {
+            "type": "integer",
+            "logic": {
+                "formula": {
+                    "==": [
+                        {
+                            "var": "count"
+                        },
+                        {
+                            "count_exact": [
+                                0,
+                                {"var": "var1"},
+                                {"var": "var2"},
+                                {"var": "var3"},
+                                {"var": "var4"},
+                                {"var": "var5"}
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    nv = create_nacc_validator(schema)
+
+    # valid case
+    assert nv.validate({"count": 5, "var1": 0, "var2": 0, "var3": 0, "var4": 0, "var5": 0})
+    assert nv.validate({"count": 4, "var1": 0, "var2": 0, "var3": 0, "var4": 0, "var5": 1})
+    assert nv.validate({"count": 3, "var1": 1, "var2": 0, "var3": 0, "var4": 0, "var5": 1})
+    assert nv.validate({"count": 0, "var1": 1, "var2": 2, "var3": 3, "var4": 4, "var5": 5})
+
+    # make sure it handles valid blank/null case
+    assert nv.validate({"count": 0})
+    assert nv.validate({"count": 2, "var5": 0, "var4": 1, "var3": 0})
+    assert nv.validate({"count": 3, "var5": 0, "var4": None, "var3": None, "var2": 0, "var1": 0})
+
+    # invalid cases
+    assert not nv.validate({"count": 0, "var1": 0, "var2": 0, "var3": 0, "var4": 0, "var5": 0})
+    assert nv.errors == {'count': ['error in formula evaluation - value 0 does not satisfy the specified formula']}
+    assert not nv.validate({"count": 5, "var1": 1, "var2": 2, "var3": 3, "var4": 4, "var5": 5})
+    assert nv.errors == {'count': ['error in formula evaluation - value 5 does not satisfy the specified formula']}
+
+    assert not nv.validate({"count": 4, "var5": 1, "var4": None, "var3": None, "var2": 0, "var1": 0})
+    assert nv.errors == {'count': ['error in formula evaluation - value 4 does not satisfy the specified formula']}
+
+def test_logic_count_exact_invalid_list(create_nacc_validator):
+    """ Checking an error is thrown if not enough arguments are passed to count_exact """
+    schema = {
+        "count": {
+            "type": "integer",
+            "logic": {
+                "formula": {
+                    "==": [
+                        {
+                            "var": "count"
+                        },
+                        {
+                            "count_exact": [
+                                1
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    nv = create_nacc_validator(schema)
+
+    assert not nv.validate({"count": 1})
+    assert nv.errors == {'count': ['error in formula evaluation - count_exact needs a base and at least 1 value to compare to']}


### PR DESCRIPTION
Adds the `count_exact` operator to `json_logic`, and updates tests/docs for it. 

Merges into the `compare_dates` branch since it requires the testing refactoring I had added there, will eventually merge to main once `compare_dates` is also merged.
