### PR TITLE
Flip compare_age comparison to be consistent with compare_with

### DIFF
--- a/docs/data-quality-rule-definition-guidelines.md
+++ b/docs/data-quality-rule-definition-guidelines.md
@@ -445,7 +445,7 @@ The rule definition for `compare_age` should follow the following format:
 
 **Example:**
 
-`behage < age at frmdate`
+`age at frmdate >= behage`
 
 <table>
 <tr>
@@ -458,7 +458,7 @@ frmdate:
   type: string
   formatting: date
   compare_age:
-    comparator: "<"
+    comparator: ">="
     birth_year: birthyr
     birth_month: birthmo
     compare_to: behage
@@ -483,7 +483,7 @@ behage:
         "type": "string",
         "formatting": "date",
         "compare_age": {
-            "comparator": "<=",
+            "comparator": ">=",
             "birth_year": "birthyr",
             "birth_month": "birthmo",
             "compare_to": "behage"

--- a/nacc_form_validator/errors.py
+++ b/nacc_form_validator/errors.py
@@ -118,7 +118,7 @@ class CustomErrorHandler(BasicErrorHandler):
             0x3002:
             "input value {0} doesn't satisfy the condition: {1}",
             0x3003:
-            "Error in comparing {0} to age {1}: {2}"
+            "Error in comparing {0} to age at {1} ({2}): {3}"
         }
 
         self.messages.update(custom_errors)

--- a/nacc_form_validator/errors.py
+++ b/nacc_form_validator/errors.py
@@ -118,7 +118,7 @@ class CustomErrorHandler(BasicErrorHandler):
             0x3002:
             "input value {0} doesn't satisfy the condition: {1}",
             0x3003:
-            "input value {0} is not a valid age to compare to {1}: {2}"
+            "Error in comparing {0} to age {1}: {2}"
         }
 
         self.messages.update(custom_errors)

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -1030,7 +1030,7 @@ class NACCValidator(Validator):
         for compare_field in ages_to_compare:
             compare_value = self.__get_value_for_key(compare_field)
             try:
-                valid = utils.compare_values(comparator, compare_value, age)
+                valid = utils.compare_values(comparator, age, compare_value)
                 if not valid:
                     self._error(field, ErrorDefs.COMPARE_AGE, compare_field,
                                 comparison_str)

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -1010,7 +1010,7 @@ class NACCValidator(Validator):
             return
 
         comparison_str = \
-            f'{", ".join(map(str, ages_to_compare))} {comparator} age at {field}'
+            f'age at {field} {comparator} {", ".join(map(str, ages_to_compare))}'
 
         # calculates age at the value of this field given the
         # birth fields and assumes the ages_to_compare values to are also numerical

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -1036,4 +1036,4 @@ class NACCValidator(Validator):
                                 comparison_str)
             except TypeError as error:
                 self._error(field, ErrorDefs.COMPARE_AGE_INVALID_COMPARISON,
-                            compare_field, field, str(error))
+                            compare_field, field, age, str(error))

--- a/tests/test_rules_compare_age.py
+++ b/tests/test_rules_compare_age.py
@@ -119,7 +119,7 @@ def test_compare_age_invalid_field(date_constraint, create_nacc_validator):
 
     nv = create_nacc_validator(schema)
     assert not nv.validate({'frmdate': '2024/02/02', 'birthyr': 2024, 'behage': "dummy_str"})
-    assert nv.errors == {'frmdate': ["Error in comparing behage to age frmdate: '<=' not supported between instances of 'float' and 'str'"]}
+    assert nv.errors == {'frmdate': ["Error in comparing behage to age at frmdate (0.08761122518822724): '<=' not supported between instances of 'float' and 'str'"]}
 
 def test_compare_age_invalid_base(create_nacc_validator):
     """ Test case where base_date is invalid """

--- a/tests/test_rules_compare_age.py
+++ b/tests/test_rules_compare_age.py
@@ -9,7 +9,7 @@ def test_compare_age(date_constraint, create_nacc_validator):
             "formatting": "date",
             "regex": date_constraint,
             "compare_age": {
-                "comparator": "<=",
+                "comparator": ">=",
                 "birth_year": "birthyr",
                 "birth_month": "birthmo",
                 "compare_to": "behage"
@@ -38,7 +38,7 @@ def test_compare_age(date_constraint, create_nacc_validator):
     # invalid cases
     assert not nv.validate({'frmdate': '2024/02/02', 'birthmo': 1, 'birthyr': 2024, 'behage': 50})
     assert nv.errors == {'frmdate': [
-                            "input value behage doesn't satisfy the condition: behage <= age at frmdate"
+                            "input value behage doesn't satisfy the condition: behage >= age at frmdate"
                         ]}
 
 def test_compare_age_list(date_constraint, create_nacc_validator):
@@ -49,7 +49,7 @@ def test_compare_age_list(date_constraint, create_nacc_validator):
             "formatting": "date",
             "regex": date_constraint,
             "compare_age": {
-                "comparator": "<=",
+                "comparator": ">=",
                 "birth_year": "birthyr",
                 "birth_month": "birthmo",
                 "compare_to": [
@@ -91,8 +91,8 @@ def test_compare_age_list(date_constraint, create_nacc_validator):
     # invalid cases
     assert not nv.validate({'frmdate': '2024/02/02', 'birthmo': 1, 'birthyr': 2024, 'behage': 50, 'cogage': 0, 'perchage': 60})
     assert nv.errors == {'frmdate': [
-                            "input value perchage doesn't satisfy the condition: behage, cogage, perchage, 0 <= age at frmdate",
-                            "input value behage doesn't satisfy the condition: behage, cogage, perchage, 0 <= age at frmdate"
+                            "input value perchage doesn't satisfy the condition: behage, cogage, perchage, 0 >= age at frmdate",
+                            "input value behage doesn't satisfy the condition: behage, cogage, perchage, 0 >= age at frmdate"
                         ]}
 
 def test_compare_age_invalid_field(date_constraint, create_nacc_validator):
@@ -119,7 +119,7 @@ def test_compare_age_invalid_field(date_constraint, create_nacc_validator):
 
     nv = create_nacc_validator(schema)
     assert not nv.validate({'frmdate': '2024/02/02', 'birthyr': 2024, 'behage': "dummy_str"})
-    assert nv.errors == {'frmdate': ["input value behage is not a valid age to compare to frmdate: '<=' not supported between instances of 'str' and 'float'"]}
+    assert nv.errors == {'frmdate': ["input value behage is not a valid age to compare to frmdate: '<=' not supported between instances of 'float' and 'str'"]}
 
 def test_compare_age_invalid_base(create_nacc_validator):
     """ Test case where base_date is invalid """

--- a/tests/test_rules_compare_age.py
+++ b/tests/test_rules_compare_age.py
@@ -38,7 +38,7 @@ def test_compare_age(date_constraint, create_nacc_validator):
     # invalid cases
     assert not nv.validate({'frmdate': '2024/02/02', 'birthmo': 1, 'birthyr': 2024, 'behage': 50})
     assert nv.errors == {'frmdate': [
-                            "input value behage doesn't satisfy the condition: behage >= age at frmdate"
+                            "input value behage doesn't satisfy the condition: age at frmdate >= behage"
                         ]}
 
 def test_compare_age_list(date_constraint, create_nacc_validator):
@@ -91,8 +91,8 @@ def test_compare_age_list(date_constraint, create_nacc_validator):
     # invalid cases
     assert not nv.validate({'frmdate': '2024/02/02', 'birthmo': 1, 'birthyr': 2024, 'behage': 50, 'cogage': 0, 'perchage': 60})
     assert nv.errors == {'frmdate': [
-                            "input value perchage doesn't satisfy the condition: behage, cogage, perchage, 0 >= age at frmdate",
-                            "input value behage doesn't satisfy the condition: behage, cogage, perchage, 0 >= age at frmdate"
+                            "input value perchage doesn't satisfy the condition: age at frmdate >= behage, cogage, perchage, 0",
+                            "input value behage doesn't satisfy the condition: age at frmdate >= behage, cogage, perchage, 0"
                         ]}
 
 def test_compare_age_invalid_field(date_constraint, create_nacc_validator):

--- a/tests/test_rules_compare_age.py
+++ b/tests/test_rules_compare_age.py
@@ -119,7 +119,7 @@ def test_compare_age_invalid_field(date_constraint, create_nacc_validator):
 
     nv = create_nacc_validator(schema)
     assert not nv.validate({'frmdate': '2024/02/02', 'birthyr': 2024, 'behage': "dummy_str"})
-    assert nv.errors == {'frmdate': ["input value behage is not a valid age to compare to frmdate: '<=' not supported between instances of 'float' and 'str'"]}
+    assert nv.errors == {'frmdate': ["Error in comparing behage to age frmdate: '<=' not supported between instances of 'float' and 'str'"]}
 
 def test_compare_age_invalid_base(create_nacc_validator):
     """ Test case where base_date is invalid """


### PR DESCRIPTION
Flips the language of the `compare_age` rule to be consistent with `compare_with`, e.g. make the `compare_to` field synonymous with `base` 