### PR TITLE
Allow temporalrules to ignore_empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Documentation of release versions of `nacc-form-validator`
 * Refactors logic for `compare_values` by moving it to its own utility method
 * Adds `previous_record` as a special keyword for `compare_with`
 * Adds `get_previous_record` method to grab previous record from Datastore, which can grab the previous record or the previous record where a specific field is non-empty
-	* Updates `_validate_temporalrules` to also support the `ignore_empty` parameter to pass to this
+	* Updates `_validate_temporalrules` to also support the `ignore_empty` parameter
 * Adds new rule `compare_age` to handle rules that need to compare ages relative to a date
 * Adds custom operator `count_exact` to `json_logic.py`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Documentation of release versions of `nacc-form-validator`
 * Refactors logic for `compare_values` by moving it to its own utility method
 * Adds `previous_record` as a special keyword for `compare_with`
 * Adds `get_previous_record` method to grab previous record from Datastore, which can grab the previous record or the previous record where a specific field is non-empty
+	* Updates `_validate_temporalrules` to also support the `ignore_empty` parameter to pass to this
 * Adds new rule `compare_age` to handle rules that need to compare ages relative to a date
 * Adds custom operator `count_exact` to `json_logic.py`
 

--- a/docs/data-quality-rule-definition-guidelines.md
+++ b/docs/data-quality-rule-definition-guidelines.md
@@ -854,9 +854,9 @@ The validator also has custom operators in addition to the ones provided by json
 Used to specify the list of checks to be performed against the previous visit for the same participant.
 * Each constraint specifies `previous` and `current` attributes. If conditions specified under `previous` subschema satisfied by the previous visit record, then the current visit record must satisfy the conditions specified under `current` subschema.
 * Each `previous/current` attribute can have several fields which need to be satisifed, with the optional `*_op` attribute specifying the boolean operation in which to compare the different fields. For example, if `prev_op = or`, then as long as _any_ of the fields satsify their schema, the `current` attribute will be evaluated. The default `*_op` is `and`.
-* Each constraint also allows for an optional `ignore_empty` boolean option, which can take a string or list of strings of fields that cannot be empty. When grabbing the previous record, the validator will grab the first previous record where all specified fields are non-empty. 
+* Each constraint also allows for an optional `ignore_empty` option, which can take a string or list of strings denoting fields that cannot be empty. When grabbing the previous record, the validator will grab the first previous record where all specified fields are non-empty. 
 
-*To validate `temporalrules`, validator should have a `Datastore` instance which will be used to retrieve the previous visit record(s) for the participant.*
+*To validate `temporalrules`, the validator should have a `Datastore` instance which will be used to retrieve the previous visit record(s) for the participant.*
 
 The rule definition for `temporalrules` should follow the following format:
 

--- a/docs/data-quality-rule-definition-guidelines.md
+++ b/docs/data-quality-rule-definition-guidelines.md
@@ -854,7 +854,8 @@ The validator also has custom operators in addition to the ones provided by json
 Used to specify the list of checks to be performed against the previous visit for the same participant.
 * Each constraint specifies `previous` and `current` attributes. If conditions specified under `previous` subschema satisfied by the previous visit record, then the current visit record must satisfy the conditions specified under `current` subschema.
 * Each `previous/current` attribute can have several fields which need to be satisifed, with the optional `*_op` attribute specifying the boolean operation in which to compare the different fields. For example, if `prev_op = or`, then as long as _any_ of the fields satsify their schema, the `current` attribute will be evaluated. The default `*_op` is `and`.
-* Each constraint also allows for an optional `ignore_empty` option, which can take a string or list of strings denoting fields that cannot be empty. When grabbing the previous record, the validator will grab the first previous record where all specified fields are non-empty. 
+* Each constraint also allows for an optional `ignore_empty` option, which can take a string or list of strings denoting fields that cannot be empty. When grabbing the previous record, the validator will grab the first previous record where all specified fields are non-empty.
+    * If no record is found that satisfies all fields being non-empty, the validator will _ignore_ the check (e.g. pass through validation without errors)
 
 *To validate `temporalrules`, the validator should have a `Datastore` instance which will be used to retrieve the previous visit record(s) for the participant.*
 

--- a/docs/data-quality-rule-definition-guidelines.md
+++ b/docs/data-quality-rule-definition-guidelines.md
@@ -854,7 +854,7 @@ The validator also has custom operators in addition to the ones provided by json
 Used to specify the list of checks to be performed against the previous visit for the same participant.
 * Each constraint specifies `previous` and `current` attributes. If conditions specified under `previous` subschema satisfied by the previous visit record, then the current visit record must satisfy the conditions specified under `current` subschema.
 * Each `previous/current` attribute can have several fields which need to be satisifed, with the optional `*_op` attribute specifying the boolean operation in which to compare the different fields. For example, if `prev_op = or`, then as long as _any_ of the fields satsify their schema, the `current` attribute will be evaluated. The default `*_op` is `and`.
-* Each constraint also allows for an optional `ignore_empty` boolean option, defaulting to False. If True, it will evaluate on the previous record where the parent `field_name` the rule is defined under is not empty
+* Each constraint also allows for an optional `ignore_empty` boolean option, which can take a string or list of strings of fields that cannot be empty. When grabbing the previous record, the validator will grab the first previous record where all specified fields are non-empty. 
 
 *To validate `temporalrules`, validator should have a `Datastore` instance which will be used to retrieve the previous visit record(s) for the participant.*
 
@@ -873,11 +873,11 @@ The rule definition for `temporalrules` should follow the following format:
                     }
                 },
                 {
-                    "ignore_empty": true,
+                    "ignore_empty": ["<field_name_1>", "<field_name_2>"],
                     "prev_op": "or",
                     "previous": {
-                        "<field_name>": "subschema to be satisfied for the previous record",
-                        "<field_name1>": "subschema to be satisfied for the previous record"
+                        "<field_name_1>": "subschema to be satisfied for the previous record",
+                        "<field_name_2>": "subschema to be satisfied for the previous record"
                     },
                     "current": {
                         "<field_name>": "subschema to be satisfied for the current record"

--- a/docs/data-quality-rule-definition-guidelines.md
+++ b/docs/data-quality-rule-definition-guidelines.md
@@ -853,7 +853,8 @@ The validator also has custom operators in addition to the ones provided by json
 
 Used to specify the list of checks to be performed against the previous visit for the same participant.
 * Each constraint specifies `previous` and `current` attributes. If conditions specified under `previous` subschema satisfied by the previous visit record, then the current visit record must satisfy the conditions specified under `current` subschema.
-* Each `previous/current` attribute can have several fields which need to be satisifed, with the `*_op` attribute specifying the boolean operation in which to compare the different fields. For example, if `prev_op = or`, then as long as _any_ of the fields satsify their schema, the `current` attribute will be evaluated. The default `*_op` is `and`.
+* Each `previous/current` attribute can have several fields which need to be satisifed, with the optional `*_op` attribute specifying the boolean operation in which to compare the different fields. For example, if `prev_op = or`, then as long as _any_ of the fields satsify their schema, the `current` attribute will be evaluated. The default `*_op` is `and`.
+* Each constraint also allows for an optional `ignore_empty` boolean option, defaulting to False. If True, it will evaluate on the previous record where the parent `field_name` the rule is defined under is not empty
 
 *To validate `temporalrules`, validator should have a `Datastore` instance which will be used to retrieve the previous visit record(s) for the participant.*
 
@@ -861,7 +862,7 @@ The rule definition for `temporalrules` should follow the following format:
 
 ```json
 {
-    "<field_name>": {
+    "<parent_field_name>": {
         "temporalrules": [
                 {
                     "previous": {
@@ -872,6 +873,7 @@ The rule definition for `temporalrules` should follow the following format:
                     }
                 },
                 {
+                    "ignore_empty": true,
                     "prev_op": "or",
                     "previous": {
                         "<field_name>": "subschema to be satisfied for the previous record",

--- a/nacc_form_validator/datastore.py
+++ b/nacc_form_validator/datastore.py
@@ -1,7 +1,7 @@
 """Datastore module."""
 
 from abc import ABC, abstractmethod
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Tuple
 
 # pylint: disable=(too-few-public-methods, no-self-use, unused-argument)
 
@@ -54,15 +54,16 @@ class Datastore(ABC):
         return None
 
     @abstractmethod
-    def get_previous_nonempty_record(self, current_record: Dict[str, str],
-                                     field: str) -> Optional[Dict[str, str]]:
-        """Abstract method to return the previous record where field is NOT
-        empty for the specified participant. Override this method to retrieve
-        the records from the desired datastore/warehouse.
+    def get_previous_nonempty_record(
+            self, current_record: Dict[str, str],
+            field: Tuple[str, List[str]]) -> Optional[Dict[str, str]]:
+        """Abstract method to return the previous record where all fields are
+        NOT empty for the specified participant. Override this method to
+        retrieve the records from the desired datastore/warehouse.
 
         Args:
             current_record: Record currently being validated
-            field: Field to check for
+            field: Field(s) to check for
 
         Returns:
             Dict[str, str]: Previous nonempty record or None if none found

--- a/nacc_form_validator/errors.py
+++ b/nacc_form_validator/errors.py
@@ -42,6 +42,7 @@ class ErrorDefs:
     DATE_CONVERSION = ErrorDefinition(0x3001, 'compare_age')
     COMPARE_AGE = ErrorDefinition(0x3002, 'compare_age')
     COMPARE_AGE_INVALID_COMPARISON = ErrorDefinition(0x3003, 'compare_age')
+    NO_PREV_NONEMPTY_VISIT = ErrorDefinition(0x3004, "temporalrules")
 
 
 class CustomErrorHandler(BasicErrorHandler):
@@ -118,7 +119,10 @@ class CustomErrorHandler(BasicErrorHandler):
             0x3002:
             "input value {0} doesn't satisfy the condition: {1}",
             0x3003:
-            "Error in comparing {0} to age at {1} ({2}): {3}"
+            "Error in comparing {0} to age at {1} ({2}): {3}",
+            0x3004:
+            "failed to retrieve the previous visit where {0} is nonempty, " +
+            "cannot proceed with validation"
         }
 
         self.messages.update(custom_errors)

--- a/nacc_form_validator/errors.py
+++ b/nacc_form_validator/errors.py
@@ -42,7 +42,6 @@ class ErrorDefs:
     DATE_CONVERSION = ErrorDefinition(0x3001, 'compare_age')
     COMPARE_AGE = ErrorDefinition(0x3002, 'compare_age')
     COMPARE_AGE_INVALID_COMPARISON = ErrorDefinition(0x3003, 'compare_age')
-    NO_PREV_NONEMPTY_VISIT = ErrorDefinition(0x3004, "temporalrules")
 
 
 class CustomErrorHandler(BasicErrorHandler):
@@ -120,9 +119,6 @@ class CustomErrorHandler(BasicErrorHandler):
             "input value {0} doesn't satisfy the condition: {1}",
             0x3003:
             "Error in comparing {0} to age at {1} ({2}): {3}",
-            0x3004:
-            "failed to retrieve the previous visit where {0} is nonempty, " +
-            "cannot proceed with validation"
         }
 
         self.messages.update(custom_errors)

--- a/nacc_form_validator/json_logic.py
+++ b/nacc_form_validator/json_logic.py
@@ -166,10 +166,10 @@ def missing_some(data, args, min_required=1):
 
 
 def count_exact(args):
-    """Counts how many items in a list match the base
+    """Counts how many items in a list match the base.
 
-    Assumes the base is the first item in `args`, and compares it against
-    the rest of the list.
+    Assumes the base is the first item in `args`, and compares it
+    against the rest of the list.
     """
     if len(args) < 2:
         raise ValueError(

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -697,17 +697,23 @@ class NACCValidator(Validator):
                 field=ignore_empty_fields,
                 ignore_empty=True if ignore_empty_fields else False)
 
-            # If temporal rules are defined, a previous vist must exist
-            if prev_ins is None:
-                if not ignore_empty_fields:
-                    self._error(field, ErrorDefs.NO_PREV_VISIT)
-                else:
-                    if isinstance(ignore_empty_fields, str):
-                        ignore_empty_fields = [ignore_empty_fields]
+            # if not found, pass through validation
+            if not prev_ins:
+                continue
 
-                    self._error(field, ErrorDefs.NO_PREV_NONEMPTY_VISIT,
-                                ', '.join(ignore_empty_fields))
-                return
+            # We are allowing a previous visit to not exist, commenting this
+            # out in case we need to bring it back
+            # # If temporal rules are defined, a previous vist must exist
+            # if prev_ins is None:
+            #     if not ignore_empty_fields:
+            #         self._error(field, ErrorDefs.NO_PREV_VISIT)
+            #     else:
+            #         if isinstance(ignore_empty_fields, str):
+            #             ignore_empty_fields = [ignore_empty_fields]
+
+            #         self._error(field, ErrorDefs.NO_PREV_NONEMPTY_VISIT,
+            #                     ', '.join(ignore_empty_fields))
+            #     return
 
             # Extract operators if specified, default is AND
             prev_operator = temporalrule.get(SchemaDefs.PREV_OP, "AND").upper()

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -697,23 +697,14 @@ class NACCValidator(Validator):
                 field=ignore_empty_fields,
                 ignore_empty=True if ignore_empty_fields else False)
 
-            # if not found, pass through validation
+            # If previous record was not found, return an error unless
+            # ignore_empty_fields was set. If it was set, then no record
+            # being returned is okay and we pass through validation
             if not prev_ins:
-                continue
-
-            # We are allowing a previous visit to not exist, commenting this
-            # out in case we need to bring it back
-            # # If temporal rules are defined, a previous vist must exist
-            # if prev_ins is None:
-            #     if not ignore_empty_fields:
-            #         self._error(field, ErrorDefs.NO_PREV_VISIT)
-            #     else:
-            #         if isinstance(ignore_empty_fields, str):
-            #             ignore_empty_fields = [ignore_empty_fields]
-
-            #         self._error(field, ErrorDefs.NO_PREV_NONEMPTY_VISIT,
-            #                     ', '.join(ignore_empty_fields))
-            #     return
+                if ignore_empty_fields:
+                    continue
+                self._error(field, ErrorDefs.NO_PREV_VISIT)
+                return
 
             # Extract operators if specified, default is AND
             prev_operator = temporalrule.get(SchemaDefs.PREV_OP, "AND").upper()

--- a/tests/test_nacc_validator_datastore.py
+++ b/tests/test_nacc_validator_datastore.py
@@ -69,14 +69,13 @@ class CustomDatastore(Datastore):
 
         sorted_record = []
         for x in self.__db[key]:
-            for field in field:
-                if x.get(field, None) is None:
-                    break
-            else:
+            nonempty = True
+            for f in field:
+                if x.get(f, None) is None:
+                    nonempty = False
+            if nonempty:
                 sorted_record.append(x)
-            break
 
-        sorted_record = [x for x in copy.deepcopy(self.__db[key]) if x.get(field, None)]
         sorted_record.append(current_record)
         sorted_record.sort(key=lambda record: record[self.orderby])
 

--- a/tests/test_nacc_validator_datastore.py
+++ b/tests/test_nacc_validator_datastore.py
@@ -133,10 +133,12 @@ def test_temporal_check_no_prev_visit(schema):
     """ Temporal test check when there are no previous visits (e.g. before visit 0) """
     nv = create_nacc_validator_with_ds(schema, 'patient_id', 'visit_num')
 
-    assert not nv.validate(
-        {'patient_id': 'PatientID1', 'visit_num': 0, 'taxes': 1})
-    assert nv.errors == {'taxes': [
-        'failed to retrieve the previous visit, cannot proceed with validation']}
+    # right now we're ignoring/allowing this case, but comment it out in case we need to bring it back
+    # assert not nv.validate(
+    #     {'patient_id': 'PatientID1', 'visit_num': 0, 'taxes': 1})
+    # assert nv.errors == {'taxes': [
+    #     'failed to retrieve the previous visit, cannot proceed with validation']}
+    assert nv.validate({'patient_id': 'PatientID1', 'visit_num': 0, 'taxes': 1})
 
 def test_temporal_check_previous_nonempty():
     """ Temporal check where previous record is nonempty """
@@ -163,8 +165,10 @@ def test_temporal_check_previous_nonempty():
     nv = create_nacc_validator_with_ds(schema, 'patient_id', 'visit_num')
     assert nv.validate({'patient_id': 'PatientID1', 'visit_num': 4, 'birthmo': 6})
 
-    assert not nv.validate({'patient_id': 'PatientID1', 'visit_num': 2, 'birthmo': 6})
-    assert nv.errors == {'birthmo': ['failed to retrieve the previous visit where birthmo, birthdy is nonempty, cannot proceed with validation']}
+    # right now we're ignoring/allowing this case, but comment it out in case we need to bring it back
+    # assert not nv.validate({'patient_id': 'PatientID1', 'visit_num': 2, 'birthmo': 6})
+    # assert nv.errors == {'birthmo': ['failed to retrieve the previous visit where birthmo, birthdy is nonempty, cannot proceed with validation']}
+    assert nv.validate({'patient_id': 'PatientID1', 'visit_num': 2, 'birthmo': 6})
 
 def test_compare_with_previous_record():
     """ Test compare_with previous record """

--- a/tests/test_nacc_validator_datastore.py
+++ b/tests/test_nacc_validator_datastore.py
@@ -133,12 +133,10 @@ def test_temporal_check_no_prev_visit(schema):
     """ Temporal test check when there are no previous visits (e.g. before visit 0) """
     nv = create_nacc_validator_with_ds(schema, 'patient_id', 'visit_num')
 
-    # right now we're ignoring/allowing this case, but comment it out in case we need to bring it back
-    # assert not nv.validate(
-    #     {'patient_id': 'PatientID1', 'visit_num': 0, 'taxes': 1})
-    # assert nv.errors == {'taxes': [
-    #     'failed to retrieve the previous visit, cannot proceed with validation']}
-    assert nv.validate({'patient_id': 'PatientID1', 'visit_num': 0, 'taxes': 1})
+    assert not nv.validate(
+        {'patient_id': 'PatientID1', 'visit_num': 0, 'taxes': 1})
+    assert nv.errors == {'taxes': [
+        'failed to retrieve the previous visit, cannot proceed with validation']}
 
 def test_temporal_check_previous_nonempty():
     """ Temporal check where previous record is nonempty """
@@ -165,9 +163,7 @@ def test_temporal_check_previous_nonempty():
     nv = create_nacc_validator_with_ds(schema, 'patient_id', 'visit_num')
     assert nv.validate({'patient_id': 'PatientID1', 'visit_num': 4, 'birthmo': 6})
 
-    # right now we're ignoring/allowing this case, but comment it out in case we need to bring it back
-    # assert not nv.validate({'patient_id': 'PatientID1', 'visit_num': 2, 'birthmo': 6})
-    # assert nv.errors == {'birthmo': ['failed to retrieve the previous visit where birthmo, birthdy is nonempty, cannot proceed with validation']}
+    # if ignore_empty is set and we cannot find a record, pass through the validation
     assert nv.validate({'patient_id': 'PatientID1', 'visit_num': 2, 'birthmo': 6})
 
 def test_compare_with_previous_record():


### PR DESCRIPTION
- Updates `_validate_temporalrules` to support grabbing the previous record where the specified fields are nonempty. Unfortunately this does mean the validator might have to grab the previous record for each constraint if they all require non-empty values. 
- Also allows for previous record to be missing (will just pass through/ignore validation)

Needed for the A3 I4 plausibility checks, e.g. 

**If DADNEUR[UDSv3] <8 at the previous visit where DADNEUR[UDSv3] is not blank, then DADETPR should not equal 00**

would be written as 
```
{
    "temporalrules": [
        {
            "index": 0,
            "ignore_empty": "dadneur",
            "previous": {
                "dadneur": {
                    "max": 7
                }
            },
            "current": {
                "dadetpr": {
                    "compare_with": {
                        "comparator": "!=",
                        "base": "00"
                    }
                }
            }
        }
    ]
}
```