### PR TITLE
Adds more testing/error verbosity, fixes nested previous records bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Documentation of release versions of `nacc-form-validator`
 * Adds support for comparing against the previous record in `compare_with`
 * Adds new rule `compare_age` to handle rules that need to compare ages relative to a date
 * Adds custom operator `count_exact` to `json_logic.py`
+* Fixes issue where `datastore` was not being set for the temp validator in `_check_subschema_valid`, causing nested conditions with previous records to not evaluate correctly
 
 ## 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Documentation of release versions of `nacc-form-validator`
 * Updates `_validate_compute_gds` to remove partial GDS score calculation
 * Updates `_check_subschema_valid` to accept an optional record parameter, defaults to the document - used for rules that require the previous record
 * Updates `compare_with` to support the `abs` operator
+* Updates `compatibility` error message to be more verbose
 * Refactors the tests to be more modularized so that they're more manageable
 * Refactors logic for `compare_values` by moving it to its own utility method
 * Adds `get_previous_record` method to grab previous record from Datastore, which can grab the previous record or the previous record where a specific field is non-empty

--- a/nacc_form_validator/errors.py
+++ b/nacc_form_validator/errors.py
@@ -26,8 +26,8 @@ class ErrorDefs:
     INVALID_DATE_MIN = ErrorDefinition(0x1005, "min")
     FILLED_TRUE = ErrorDefinition(0x1006, "filled")
     FILLED_FALSE = ErrorDefinition(0x1007, "filled")
-    COMPATIBILITY_TRUE = ErrorDefinition(0x1008, "compatibility")
-    COMPATIBILITY_FALSE = ErrorDefinition(0x1009, "compatibility")
+    COMPATIBILITY = ErrorDefinition(0x1008, "compatibility")
+    COMPATIBILITY_ELSE = ErrorDefinition(0x1009, "compatibility")
     TEMPORAL = ErrorDefinition(0x2000, "temporalrules")
     NO_PRIMARY_KEY = ErrorDefinition(0x2001, "temporalrules")
     NO_PREV_VISIT = ErrorDefinition(0x2002, "temporalrules")
@@ -84,9 +84,9 @@ class CustomErrorHandler(BasicErrorHandler):
             0x1007:
             "must be empty",
             0x1008:
-            "{1} for {2} - compatibility rule no: {0}",
+            "{1} for if {2} then {3} - compatibility rule no: {0}",
             0x1009:
-            "{1} for {2} - compatibility rule no: {0}",
+            "{1} for if {2} else {3} - compatibility rule no: {0}",
             0x2000:
             "{1} in current visit for {2} in previous visit - temporal rule no: {0}",
             0x2001:

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -501,6 +501,12 @@ class NACCValidator(Validator):
                 allow_unknown=True,
                 error_handler=CustomErrorHandler(subschema),
             )
+
+            # pass the same datastore
+            if self.primary_key and self.datastore:
+                temp_validator.primary_key = self.primary_key
+                temp_validator.datastore = self.datastore
+
             if operator == "OR":
                 valid = valid or temp_validator.validate(record,
                                                          normalize=False)

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -600,7 +600,7 @@ class NACCValidator(Validator):
             else_conds = constraint.get(SchemaDefs.ELSE, None)
 
             # Check if dependencies satisfied the If clause
-            error_def = ErrorDefs.COMPATIBILITY_FALSE
+            error_def = ErrorDefs.COMPATIBILITY
             errors = None
             valid, _ = self._check_subschema_valid(if_conds, if_operator)
 
@@ -608,21 +608,24 @@ class NACCValidator(Validator):
             if valid:
                 valid, errors = self._check_subschema_valid(
                     then_conds, then_operator)
-                error_def = ErrorDefs.COMPATIBILITY_TRUE
 
             # Otherwise validate the else clause, if they exist
             elif else_conds:
                 valid, errors = self._check_subschema_valid(
                     else_conds, else_operator)
-                error_def = ErrorDefs.COMPATIBILITY_FALSE
+                error_def = ErrorDefs.COMPATIBILITY_ELSE
             else:  # if the If condition is not satisfied, do nothing
                 pass
 
             # Something in the then/else clause failed - report errors
             if errors:
                 for error in errors.items():
-                    self._error(field, error_def, rule_no, str(error),
-                                if_conds)
+                    if error_def == ErrorDefs.COMPATIBILITY:
+                        self._error(field, error_def, rule_no, str(error),
+                                    if_conds, then_conds)
+                    else:
+                        self._error(field, error_def, rule_no, str(error),
+                                    if_conds, else_conds)
 
     # pylint: disable=(too-many-locals)
     def _validate_temporalrules(self, temporalrules: List[Mapping], field: str,

--- a/tests/test_nacc_validator.py
+++ b/tests/test_nacc_validator.py
@@ -131,9 +131,9 @@ def test_lots_of_rules(create_nacc_validator):
 
     # invalid cases - compatibility
     assert not nv.validate({'adcid': 0, 'prevenrl': 1, 'oldadcid': None})
-    assert nv.errors == {'oldadcid': ["('oldadcid', ['null value not allowed']) for {'prevenrl': {'allowed': [1]}} - compatibility rule no: 0"]}
+    assert nv.errors == {'oldadcid': ["('oldadcid', ['null value not allowed']) for if {'prevenrl': {'allowed': [1]}} then {'oldadcid': {'nullable': False}} - compatibility rule no: 0"]}
     assert not nv.validate({'adcid': 0, 'prevenrl': 0, 'oldadcid': 1})
-    assert nv.errors == {'oldadcid': ["('oldadcid', ['must be empty']) for {'prevenrl': {'allowed': [0, 9]}} - compatibility rule no: 1"]}
+    assert nv.errors == {'oldadcid': ["('oldadcid', ['must be empty']) for if {'prevenrl': {'allowed': [0, 9]}} then {'oldadcid': {'nullable': True, 'filled': False}} - compatibility rule no: 1"]}
 
     # invalid cases, logic (adcid != oldadcid)
     assert not nv.validate({'adcid': 0, 'prevenrl': 1, 'oldadcid': 0})

--- a/tests/test_rules_compatibility.py
+++ b/tests/test_rules_compatibility.py
@@ -46,15 +46,15 @@ def test_compatibility_if_then(create_nacc_validator):
     assert not nv.validate({'mode': 2, 'rmreason': 9})
     assert nv.errors == {'rmreason': ['unallowed value 9']}
     assert not nv.validate({'mode': 2, 'rmreason': None})
-    assert nv.errors == {'rmreason': ["('rmreason', ['null value not allowed']) for {'mode': {'allowed': [2]}} - compatibility rule no: 0"]}
+    assert nv.errors == {'rmreason': ["('rmreason', ['null value not allowed']) for if {'mode': {'allowed': [2]}} then {'rmreason': {'nullable': False}} - compatibility rule no: 0"]}
 
     # invalid cases for second condition
     assert not nv.validate({'mode': 3, 'rmreason': 1})
-    assert nv.errors == {'rmreason': ["('rmreason', ['must be empty']) for {'mode': {'allowed': [1, 3]}} - compatibility rule no: 1"]}
+    assert nv.errors == {'rmreason': ["('rmreason', ['must be empty']) for if {'mode': {'allowed': [1, 3]}} then {'rmreason': {'nullable': True, 'filled': False}} - compatibility rule no: 1"]}
     assert not nv.validate({'mode': 1, 'rmreason': 5})
-    assert nv.errors == {'rmreason': ["('rmreason', ['must be empty']) for {'mode': {'allowed': [1, 3]}} - compatibility rule no: 1"]}
+    assert nv.errors == {'rmreason': ["('rmreason', ['must be empty']) for if {'mode': {'allowed': [1, 3]}} then {'rmreason': {'nullable': True, 'filled': False}} - compatibility rule no: 1"]}
     assert not nv.validate({'mode': 1, 'rmreason': 9})
-    assert nv.errors == {'rmreason': ['unallowed value 9', "('rmreason', ['must be empty']) for {'mode': {'allowed': [1, 3]}} - compatibility rule no: 1"]}
+    assert nv.errors ==  {'rmreason': ['unallowed value 9', "('rmreason', ['must be empty']) for if {'mode': {'allowed': [1, 3]}} then {'rmreason': {'nullable': True, 'filled': False}} - compatibility rule no: 1"]}
 
 def test_compatibility_with_nested_logic_or(create_nacc_validator):
     """ Test when the rule has a nested compatibility - or logic """
@@ -113,11 +113,11 @@ def test_compatibility_with_nested_logic_or(create_nacc_validator):
 
     # the compatibility if/then with logic inside means that raceunkn cannot be 1 if any of the others are set
     assert not nv.validate({'raceaian': 1, 'raceunkn': 1})
-    assert nv.errors == {'raceunkn': ["('raceunkn', ['must be empty']) for {'raceaian': {'logic': {'formula': {'or': [{'==': [1, {'var': 'raceaian'}]}, {'==': [1, {'var': 'raceasian'}]}, {'==': [1, {'var': 'raceblack'}]}]}}}} - compatibility rule no: 0"]}
+    assert nv.errors == {'raceunkn': ["('raceunkn', ['must be empty']) for if {'raceaian': {'logic': {'formula': {'or': [{'==': [1, {'var': 'raceaian'}]}, {'==': [1, {'var': 'raceasian'}]}, {'==': [1, {'var': 'raceblack'}]}]}}}} then {'raceunkn': {'nullable': True, 'filled': False}} - compatibility rule no: 0"]}
     assert not nv.validate({'raceasian': 1, 'raceunkn': 1})
-    assert nv.errors == {'raceunkn': ["('raceunkn', ['must be empty']) for {'raceaian': {'logic': {'formula': {'or': [{'==': [1, {'var': 'raceaian'}]}, {'==': [1, {'var': 'raceasian'}]}, {'==': [1, {'var': 'raceblack'}]}]}}}} - compatibility rule no: 0"]}
+    assert nv.errors == {'raceunkn': ["('raceunkn', ['must be empty']) for if {'raceaian': {'logic': {'formula': {'or': [{'==': [1, {'var': 'raceaian'}]}, {'==': [1, {'var': 'raceasian'}]}, {'==': [1, {'var': 'raceblack'}]}]}}}} then {'raceunkn': {'nullable': True, 'filled': False}} - compatibility rule no: 0"]}
     assert not nv.validate({'raceblack': 1, 'raceunkn': 1})
-    assert nv.errors == {'raceunkn': ["('raceunkn', ['must be empty']) for {'raceaian': {'logic': {'formula': {'or': [{'==': [1, {'var': 'raceaian'}]}, {'==': [1, {'var': 'raceasian'}]}, {'==': [1, {'var': 'raceblack'}]}]}}}} - compatibility rule no: 0"]}
+    assert nv.errors == {'raceunkn': ["('raceunkn', ['must be empty']) for if {'raceaian': {'logic': {'formula': {'or': [{'==': [1, {'var': 'raceaian'}]}, {'==': [1, {'var': 'raceasian'}]}, {'==': [1, {'var': 'raceblack'}]}]}}}} then {'raceunkn': {'nullable': True, 'filled': False}} - compatibility rule no: 0"]}
 
 def test_multiple_compatibility(create_nacc_validator):
     """ Test multiple compatibility rules """
@@ -162,9 +162,9 @@ def test_multiple_compatibility(create_nacc_validator):
 
     # invalid cases
     assert not nv.validate({'enrlgenoth': 1, 'enrlgenothx': None})
-    assert nv.errors == {'enrlgenothx': ["('enrlgenothx', ['null value not allowed']) for {'enrlgenoth': {'allowed': [1]}} - compatibility rule no: 0"]}
+    assert nv.errors == {'enrlgenothx': ["('enrlgenothx', ['null value not allowed']) for if {'enrlgenoth': {'allowed': [1]}} then {'enrlgenothx': {'nullable': False}} - compatibility rule no: 0"]}
     assert not nv.validate({'enrlgenoth': None, 'enrlgenothx': 'somevalue'})
-    assert nv.errors == {'enrlgenothx': ["('enrlgenothx', ['must be empty']) for {'enrlgenoth': {'nullable': True, 'filled': False}} - compatibility rule no: 1"]}
+    assert nv.errors == {'enrlgenothx': ["('enrlgenothx', ['must be empty']) for if {'enrlgenoth': {'nullable': True, 'filled': False}} then {'enrlgenothx': {'nullable': True, 'filled': False}} - compatibility rule no: 1"]}
 
 def test_compatibility_multiple_variables_and(create_nacc_validator):
     """ Test when the compatibility relies on two variables on an "and" operator """
@@ -203,9 +203,9 @@ def test_compatibility_multiple_variables_and(create_nacc_validator):
     assert nv.validate({"majordep": 1, "otherdep": 2, "deprtreat": 1})
 
     assert not nv.validate({"majordep": 0, "otherdep": 2, "deprtreat": 1})
-    assert nv.errors == {'deprtreat': ["('deprtreat', ['must be empty']) for {'majordep': {'allowed': [0, 2, 9]}, 'otherdep': {'allowed': [0, 2, 9]}} - compatibility rule no: 0"]}
+    assert nv.errors == {'deprtreat': ["('deprtreat', ['must be empty']) for if {'majordep': {'allowed': [0, 2, 9]}, 'otherdep': {'allowed': [0, 2, 9]}} then {'deprtreat': {'nullable': True, 'filled': False}} - compatibility rule no: 0"]}
     assert not nv.validate({"majordep": 2, "otherdep": 9, "deprtreat": 0})
-    assert nv.errors == {'deprtreat': ["('deprtreat', ['must be empty']) for {'majordep': {'allowed': [0, 2, 9]}, 'otherdep': {'allowed': [0, 2, 9]}} - compatibility rule no: 0"]}
+    assert nv.errors == {'deprtreat': ["('deprtreat', ['must be empty']) for if {'majordep': {'allowed': [0, 2, 9]}, 'otherdep': {'allowed': [0, 2, 9]}} then {'deprtreat': {'nullable': True, 'filled': False}} - compatibility rule no: 0"]}
 
 def test_compatibility_multiple_variables_or(create_nacc_validator):
     """ Test when the compatibility relies on two variables on an "or" operator """
@@ -246,11 +246,11 @@ def test_compatibility_multiple_variables_or(create_nacc_validator):
     assert nv.validate({"majordep": 9, "otherdep": 1, "deprtreat": 0})
 
     assert not nv.validate({"majordep": 1, "otherdep": 2, "deprtreat": None})
-    assert nv.errors == {'deprtreat': ["('deprtreat', ['null value not allowed']) for {'majordep': {'allowed': [1]}, 'otherdep': {'allowed': [1]}} - compatibility rule no: 0"]}
+    assert nv.errors == {'deprtreat': ["('deprtreat', ['null value not allowed']) for if {'majordep': {'allowed': [1]}, 'otherdep': {'allowed': [1]}} then {'deprtreat': {'nullable': False}} - compatibility rule no: 0"]}
     assert not nv.validate({"majordep": 9, "otherdep": 1, "deprtreat": None})
-    assert nv.errors == {'deprtreat': ["('deprtreat', ['null value not allowed']) for {'majordep': {'allowed': [1]}, 'otherdep': {'allowed': [1]}} - compatibility rule no: 0"]}
+    assert nv.errors == {'deprtreat': ["('deprtreat', ['null value not allowed']) for if {'majordep': {'allowed': [1]}, 'otherdep': {'allowed': [1]}} then {'deprtreat': {'nullable': False}} - compatibility rule no: 0"]}
     assert not nv.validate({"majordep": 1, "otherdep": 1, "deprtreat": None})
-    assert nv.errors == {'deprtreat': ["('deprtreat', ['null value not allowed']) for {'majordep': {'allowed': [1]}, 'otherdep': {'allowed': [1]}} - compatibility rule no: 0"]}
+    assert nv.errors == {'deprtreat': ["('deprtreat', ['null value not allowed']) for if {'majordep': {'allowed': [1]}, 'otherdep': {'allowed': [1]}} then {'deprtreat': {'nullable': False}} - compatibility rule no: 0"]}
 
 def test_compatibility_then_multiple_blank_and(create_nacc_validator):
     """ Test when the rule results in multiple things needing to be blank """
@@ -292,12 +292,12 @@ def test_compatibility_then_multiple_blank_and(create_nacc_validator):
     assert nv.validate({"parentvar": 0, "var1": None, "var2": 2, "var3": None})
 
     assert not nv.validate({"parentvar": None, "var1": 1, "var2": None, "var3": None})
-    assert nv.errors == {'var1': ["('var1', ['must be empty']) for {'parentvar': {'nullable': True, 'filled': False}} - compatibility rule no: 0"]}
+    assert nv.errors == {'var1': ["('var1', ['must be empty']) for if {'parentvar': {'nullable': True, 'filled': False}} then {'var1': {'nullable': True, 'filled': False}, 'var2': {'nullable': True, 'filled': False}, 'var3': {'nullable': True, 'filled': False}} - compatibility rule no: 0"]}
     assert not nv.validate({"parentvar": None, "var1": 1, "var2": 1, "var3": 1})
-    assert nv.errors == {'var1': ["('var1', ['must be empty']) for {'parentvar': {'nullable': True, 'filled': False}} - compatibility rule no: 0"]}
+    assert nv.errors == {'var1': ["('var1', ['must be empty']) for if {'parentvar': {'nullable': True, 'filled': False}} then {'var1': {'nullable': True, 'filled': False}, 'var2': {'nullable': True, 'filled': False}, 'var3': {'nullable': True, 'filled': False}} - compatibility rule no: 0"]}
     
     assert not nv.validate({"parentvar": None, "var1": None, "var2": None, "var3": 1})
-    assert nv.errors == {'var1': ["('var3', ['must be empty']) for {'parentvar': {'nullable': True, 'filled': False}} - compatibility rule no: 0"]}
+    assert nv.errors == {'var1': ["('var3', ['must be empty']) for if {'parentvar': {'nullable': True, 'filled': False}} then {'var1': {'nullable': True, 'filled': False}, 'var2': {'nullable': True, 'filled': False}, 'var3': {'nullable': True, 'filled': False}} - compatibility rule no: 0"]}
 
 def test_compatibility_then_multiple_blank_logic_and(create_nacc_validator):
     """ Test when the rule results in multiple things needing to be blank - logic """
@@ -348,14 +348,14 @@ def test_compatibility_then_multiple_blank_logic_and(create_nacc_validator):
     assert nv.validate({"parentvar": 0, "var1": None, "var2": 2, "var3": None})
 
     assert not nv.validate({"parentvar": None, "var1": 1, "var2": None, "var3": None})
-    assert nv.errors == {'var1': ["('var1', ['error in formula evaluation - value 1 does not satisfy the specified formula']) for {'parentvar': {'nullable': True, 'filled': False}} - compatibility rule no: 0"]}
+    assert nv.errors == {'var1': ["('var1', ['error in formula evaluation - value 1 does not satisfy the specified formula']) for if {'parentvar': {'nullable': True, 'filled': False}} then {'var1': {'nullable': True, 'logic': {'formula': {'and': [{'==': [None, {'var': 'var1'}]}, {'==': [None, {'var': 'var2'}]}, {'==': [None, {'var': 'var3'}]}]}}}} - compatibility rule no: 0"]}
     assert not nv.validate({"parentvar": None, "var1": 1, "var2": 1, "var3": 1})
-    assert nv.errors == {'var1': ["('var1', ['error in formula evaluation - value 1 does not satisfy the specified formula']) for {'parentvar': {'nullable': True, 'filled': False}} - compatibility rule no: 0"]}
+    assert nv.errors == {'var1': ["('var1', ['error in formula evaluation - value 1 does not satisfy the specified formula']) for if {'parentvar': {'nullable': True, 'filled': False}} then {'var1': {'nullable': True, 'logic': {'formula': {'and': [{'==': [None, {'var': 'var1'}]}, {'==': [None, {'var': 'var2'}]}, {'==': [None, {'var': 'var3'}]}]}}}} - compatibility rule no: 0"]}
     
     # TODO: it looks like this error message is misleading, it fails because of var3 not var1 but since this logic is on var1 its reported as a var1 failure
     #       something to improve on. But also because of this you should avoid using logic and instead do it as shown in test_compatibility_then_multiple_blank_and
     assert not nv.validate({"parentvar": None, "var1": None, "var2": None, "var3": 1})
-    assert nv.errors == {'var1': ["('var1', ['error in formula evaluation - value None does not satisfy the specified formula']) for {'parentvar': {'nullable': True, 'filled': False}} - compatibility rule no: 0"]}
+    assert nv.errors == {'var1': ["('var1', ['error in formula evaluation - value None does not satisfy the specified formula']) for if {'parentvar': {'nullable': True, 'filled': False}} then {'var1': {'nullable': True, 'logic': {'formula': {'and': [{'==': [None, {'var': 'var1'}]}, {'==': [None, {'var': 'var2'}]}, {'==': [None, {'var': 'var3'}]}]}}}} - compatibility rule no: 0"]}
 
 def test_compatibility_multiple_resulting_variables_or(create_nacc_validator):
     """ Tests a "If X is 1, than Y or Z should be 1", and "If X i 0, then Y and Z should be 0" situation """
@@ -373,6 +373,7 @@ def test_compatibility_multiple_resulting_variables_or(create_nacc_validator):
             "required": True,
             "compatibility": [
                 {
+                    "index": 0,
                     "then_op": "or",
                     "if": {
                         "hall": {"allowed": [1]}
@@ -383,6 +384,7 @@ def test_compatibility_multiple_resulting_variables_or(create_nacc_validator):
                     }
                 },
                 {
+                    "index": 1,
                     "then_op": "and",
                     "if": {
                         "hall": {"allowed": [0]}
@@ -405,11 +407,13 @@ def test_compatibility_multiple_resulting_variables_or(create_nacc_validator):
     assert nv.validate({"hall": 0, "bevhall": 0, "beahall": 0})
 
     assert not nv.validate({"hall": 1, "bevhall": 0, "beahall": 0})
-    assert nv.errors == {'hall': ["('beahall', ['unallowed value 0']) for {'hall': {'allowed': [1]}} - compatibility rule no: 0", "('bevhall', ['unallowed value 0']) for {'hall': {'allowed': [1]}} - compatibility rule no: 0"]}
+    # TODO: the duplicate error message is due to the `then_op: or` clause - should probably fix
+    assert nv.errors == {'hall': ["('beahall', ['unallowed value 0']) for if {'hall': {'allowed': [1]}} then {'bevhall': {'allowed': [1]}, 'beahall': {'allowed': [1]}} - compatibility rule no: 0",
+                                  "('bevhall', ['unallowed value 0']) for if {'hall': {'allowed': [1]}} then {'bevhall': {'allowed': [1]}, 'beahall': {'allowed': [1]}} - compatibility rule no: 0"]}
     assert not nv.validate({"hall": 0, "bevhall": 0, "beahall": 1})
-    assert nv.errors == {'hall': ["('beahall', ['unallowed value 1']) for {'hall': {'allowed': [0]}} - compatibility rule no: 1"]}
+    assert nv.errors == {'hall': ["('beahall', ['unallowed value 1']) for if {'hall': {'allowed': [0]}} then {'bevhall': {'allowed': [0]}, 'beahall': {'allowed': [0]}} - compatibility rule no: 1"]}
     assert not nv.validate({"hall": 0, "bevhall": None, "beahall": None})
-    assert nv.errors == {'hall': ["('bevhall', ['null value not allowed']) for {'hall': {'allowed': [0]}} - compatibility rule no: 1"]}
+    assert nv.errors == {'hall': ["('bevhall', ['null value not allowed']) for if {'hall': {'allowed': [0]}} then {'bevhall': {'allowed': [0]}, 'beahall': {'allowed': [0]}} - compatibility rule no: 1"]}
 
 def test_compatibility_multiple_resulting_options_or(create_nacc_validator):
     """ Tests a "If X is 1, than Y and Z should be 0 or 2" situation """
@@ -460,7 +464,7 @@ def test_compatibility_multiple_resulting_options_or(create_nacc_validator):
     assert nv.validate({"depd": 5, "majdepdx": 1, "othdepdx": 1})
 
     assert not nv.validate({"depd": 2, "majdepdx": 0, "othdepdx": 2})
-    assert nv.errors == {'depd': ["('majdepdx', ['unallowed value 0']) for {'depd': {'allowed': [2]}} - compatibility rule no: 2"]}
+    assert nv.errors == {'depd': ["('majdepdx', ['unallowed value 0']) for if {'depd': {'allowed': [2]}} then {'majdepdx': {'allowed': [1]}, 'othdepdx': {'allowed': [1]}} - compatibility rule no: 2"]}
     assert not nv.validate({"depd": None, "majdepdx": 0, "othdepdx": 2})
     assert nv.errors == {'depd': ['null value not allowed']}
 
@@ -497,9 +501,9 @@ def test_compatibility_multiple_else(create_nacc_validator):
     assert nv.validate({"var1": 1, "var2": 2})
 
     assert not nv.validate({"var1": 0, "var2": 8})
-    assert nv.errors == {'var1': ["('var2', ['unallowed value 8']) for {'var1': {'allowed': [1]}} - compatibility rule no: 0"]}
+    assert nv.errors == {'var1': ["('var2', ['unallowed value 8']) for if {'var1': {'allowed': [1]}} else {'var2': {'allowed': [3, 4, 5]}} - compatibility rule no: 0"]}
     assert not nv.validate({"var1": 1, "var2": 3})
-    assert nv.errors == {'var1': ["('var2', ['unallowed value 3']) for {'var1': {'allowed': [1]}} - compatibility rule no: 0"]}
+    assert nv.errors == {'var1': ["('var2', ['unallowed value 3']) for if {'var1': {'allowed': [1]}} then {'var2': {'allowed': [2]}} - compatibility rule no: 0"]}
 
 def test_compatibility_multiple_else_and_multiple_conditions(create_nacc_validator):
     """ Tests the else clause with multiple conditions. If VAR1 is 1 then VAR2 is 2, else VAR2 3-5 OR VAR3 is 9 """
@@ -541,16 +545,20 @@ def test_compatibility_multiple_else_and_multiple_conditions(create_nacc_validat
     assert nv.validate({"var1": 1, "var2": 2, "var3": None})
 
     assert not nv.validate({"var1": 1, "var2": 3, "var3": None})
-    assert nv.errors == {'var1': ["('var2', ['unallowed value 3']) for {'var1': {'allowed': [1]}} - compatibility rule no: 0"]}
+    assert nv.errors == {'var1': ["('var2', ['unallowed value 3']) for if {'var1': {'allowed': [1]}} then {'var2': {'allowed': [2]}} - compatibility rule no: 0"]}
     assert not nv.validate({"var1": 1, "var2": None, "var3": 6})
-    assert nv.errors == {'var1': ["('var2', ['null value not allowed']) for {'var1': {'allowed': [1]}} - compatibility rule no: 0"]}
+    assert nv.errors == {'var1': ["('var2', ['null value not allowed']) for if {'var1': {'allowed': [1]}} then {'var2': {'allowed': [2]}} - compatibility rule no: 0"]}
 
     assert not nv.validate({"var1": 0, "var2": 8, "var3": None})
-    assert nv.errors == {'var1': ["('var3', ['null value not allowed']) for {'var1': {'allowed': [1]}} - compatibility rule no: 0", "('var2', ['unallowed value 8']) for {'var1': {'allowed': [1]}} - compatibility rule no: 0"]}
+    assert nv.errors == {'var1': ["('var3', ['null value not allowed']) for if {'var1': {'allowed': [1]}} else {'var2': {'allowed': [3, 4, 5]}, 'var3': {'allowed': [9]}} - compatibility rule no: 0",
+                                  "('var2', ['unallowed value 8']) for if {'var1': {'allowed': [1]}} else {'var2': {'allowed': [3, 4, 5]}, 'var3': {'allowed': [9]}} - compatibility rule no: 0"]}
     assert not nv.validate({"var1": 0, "var2": None, "var3": None})
-    assert nv.errors == {'var1': ["('var3', ['null value not allowed']) for {'var1': {'allowed': [1]}} - compatibility rule no: 0", "('var2', ['null value not allowed']) for {'var1': {'allowed': [1]}} - compatibility rule no: 0"]}
+    assert nv.errors == {'var1': ["('var3', ['null value not allowed']) for if {'var1': {'allowed': [1]}} else {'var2': {'allowed': [3, 4, 5]}, 'var3': {'allowed': [9]}} - compatibility rule no: 0",
+                                  "('var2', ['null value not allowed']) for if {'var1': {'allowed': [1]}} else {'var2': {'allowed': [3, 4, 5]}, 'var3': {'allowed': [9]}} - compatibility rule no: 0"]}
+
     assert not nv.validate({"var1": 0, "var2": None, "var3": 16})
-    assert nv.errors == {'var1': ["('var3', ['unallowed value 16']) for {'var1': {'allowed': [1]}} - compatibility rule no: 0", "('var2', ['null value not allowed']) for {'var1': {'allowed': [1]}} - compatibility rule no: 0"]}
+    assert nv.errors == {'var1': ["('var3', ['unallowed value 16']) for if {'var1': {'allowed': [1]}} else {'var2': {'allowed': [3, 4, 5]}, 'var3': {'allowed': [9]}} - compatibility rule no: 0",
+                                  "('var2', ['null value not allowed']) for if {'var1': {'allowed': [1]}} else {'var2': {'allowed': [3, 4, 5]}, 'var3': {'allowed': [9]}} - compatibility rule no: 0"]}
 
 def test_compatibility_nested_anyof(create_nacc_validator):
     """ Tests when anyof is nested inside compatibility. """
@@ -613,10 +621,179 @@ def test_compatibility_nested_anyof(create_nacc_validator):
 
     for i in range (5, 26):
         assert not nv.validate({"menarche": 5, "nomensage": None})
-    assert nv.errors == {'nomensage': ["('nomensage', ['null value not allowed']) for {'menarche': {'anyof': [{'min': 5, 'max': 25}, {'allowed': [99]}]}} - compatibility rule no: 0"]}
+    assert nv.errors == {'nomensage': ["('nomensage', ['null value not allowed']) for if {'menarche': {'anyof': [{'min': 5, 'max': 25}, {'allowed': [99]}]}} then {'nomensage': {'nullable': False}} - compatibility rule no: 0"]}
     assert not nv.validate({"menarche": 99, "nomensage": None})
-    assert nv.errors == {'nomensage': ["('nomensage', ['null value not allowed']) for {'menarche': {'anyof': [{'min': 5, 'max': 25}, {'allowed': [99]}]}} - compatibility rule no: 0"]}
+    assert nv.errors == {'nomensage': ["('nomensage', ['null value not allowed']) for if {'menarche': {'anyof': [{'min': 5, 'max': 25}, {'allowed': [99]}]}} then {'nomensage': {'nullable': False}} - compatibility rule no: 0"]}
     assert not nv.validate({"menarche": 88, "nomensage": 10})
-    assert nv.errors == {'nomensage': ["('nomensage', ['must be empty']) for {'menarche': {'nullable': True, 'anyof': [{'nullable': True, 'filled': False}, {'allowed': [88]}]}} - compatibility rule no: 1"]}
+    assert nv.errors == {'nomensage': ["('nomensage', ['must be empty']) for if {'menarche': {'nullable': True, 'anyof': [{'nullable': True, 'filled': False}, {'allowed': [88]}]}} then {'nomensage': {'nullable': True, 'filled': False}} - compatibility rule no: 1"]}
     assert not nv.validate({"menarche": None, "nomensage": 10})
-    assert nv.errors == {'nomensage': ["('nomensage', ['must be empty']) for {'menarche': {'nullable': True, 'anyof': [{'nullable': True, 'filled': False}, {'allowed': [88]}]}} - compatibility rule no: 1"]}
+    assert nv.errors == {'nomensage': ["('nomensage', ['must be empty']) for if {'menarche': {'nullable': True, 'anyof': [{'nullable': True, 'filled': False}, {'allowed': [88]}]}} then {'nomensage': {'nullable': True, 'filled': False}} - compatibility rule no: 1"]}
+
+def test_compatibility_logic_with_divide(create_nacc_validator):
+    """ Testing case where logic is dividing something - we need to ensure we do not divide by 0
+        This is a truncated/modified version of the C2F ftdsnrat case """
+    schema = {
+        "ftdhaird": {
+            "nullable": True,
+            "type": "integer",
+            "allowed": [0, 1]
+        },
+        "ftdspit": {
+            "nullable": True,
+            "type": "integer",
+            "allowed": [0, 1]
+        },
+        "ftdnose": {
+            "nullable": True,
+            "type": "integer",
+            "allowed": [0, 1]
+        },
+        "ftdsnrat": {
+            "nullable": True,
+            "type": "float",
+            "anyof": [
+                {"min": 0.0, "max": 3.0},
+                {"allowed": [88.88]}
+            ],
+            "compatibility": [
+                {
+                    "index": 0,
+                    "if_op": "and",
+                    "if": {
+                        "ftdhaird": {
+                            "allowed": [0, 1]
+                        },
+                        "ftdspit": {
+                            "allowed": [0, 1]
+                        },
+                        "ftdnose": {
+                            "allowed": [0, 1]
+                        },
+                        "ftdsnrat": {
+                            "logic": {
+                                "formula": {
+                                    "and": [
+                                        {
+                                            "!=": [
+                                                0,
+                                                {
+                                                    "count_exact": [
+                                                        0,
+                                                        {"var": "ftdhaird"},
+                                                        {"var": "ftdspit"},
+                                                        {"var": "ftdnose"}
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "!=": [
+                                                0,
+                                                {
+                                                    "count_exact": [
+                                                        1,
+                                                        {"var": "ftdhaird"},
+                                                        {"var": "ftdspit"},
+                                                        {"var": "ftdnose"}
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "then": {
+                        "ftdsnrat": {
+                            "logic": {
+                                "formula": {
+                                    "==": [
+                                        {"var": "ftdsnrat"},
+                                        {
+                                            "/": [
+                                                {
+                                                    "count_exact": [
+                                                        1,
+                                                        {"var": "ftdhaird"},
+                                                        {"var": "ftdspit"},
+                                                        {"var": "ftdnose"}
+                                                    ]
+                                                },
+                                                {
+                                                    "count_exact": [
+                                                        0,
+                                                        {"var": "ftdhaird"},
+                                                        {"var": "ftdspit"},
+                                                        {"var": "ftdnose"}
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "index": 1,
+                    "if_op": "or",
+                    "if": {
+                        "ftdhaird": { "nullable": True, "filled": False },
+                        "ftdspit": { "nullable": True, "filled": False },
+                        "ftdnose": { "nullable": True, "filled": False }
+                    },
+                    "then": {
+                        "ftdsnrat": {
+                            "allowed": [88.88]
+                        }
+                    }
+                },
+                {
+                    "index": 2,
+                    "if_op": "and",
+                    "if": {
+                        "ftdhaird": { "allowed": [0] },
+                        "ftdspit": { "allowed": [0] },
+                        "ftdnose": { "allowed": [0] }
+                    },
+                    "then": {
+                        "ftdsnrat": {
+                            "allowed": [88.88]
+                        }
+                    }
+                },
+                {
+                    "index": 3,
+                    "if_op": "and",
+                    "if": {
+                        "ftdhaird": { "allowed": [1] },
+                        "ftdspit": { "allowed": [1] },
+                        "ftdnose": { "allowed": [1] }
+                    },
+                    "then": {
+                        "ftdsnrat": {
+                            "allowed": [88.88]
+                        }
+                    }
+                }
+            ]
+        }
+    }
+    nv = create_nacc_validator(schema)
+
+    assert nv.validate({"ftdsnrat": 88.88, "ftdhaird": 0, "ftdspit": 0, "ftdnose": 0})
+    assert nv.validate({"ftdsnrat": 88.88, "ftdhaird": 1, "ftdspit": 1, "ftdnose": 1})
+    assert nv.validate({"ftdsnrat": 88.88, "ftdhaird": None, "ftdspit": None, "ftdnose": None})
+    assert nv.validate({"ftdsnrat": 88.88, "ftdhaird": None, "ftdspit": None, "ftdnose": 0})
+    assert nv.validate({"ftdsnrat": 88.88, "ftdhaird": None, "ftdspit": 1, "ftdnose": 0})
+
+    assert nv.validate({"ftdsnrat": 2.0 , "ftdhaird": 1, "ftdspit": 1, "ftdnose": 0})
+    assert nv.validate({"ftdsnrat": 0.5 , "ftdhaird": 0, "ftdspit": 1, "ftdnose": 0})
+
+    assert not nv.validate({"ftdsnrat": 0.0 , "ftdhaird": 0, "ftdspit": 0, "ftdnose": 0})
+    assert nv.errors == {'ftdsnrat': ["('ftdsnrat', ['unallowed value 0.0']) for if {'ftdhaird': {'allowed': [0]}, 'ftdspit': {'allowed': [0]}, 'ftdnose': {'allowed': [0]}} then {'ftdsnrat': {'allowed': [88.88]}} - compatibility rule no: 2"]}
+
+    assert not nv.validate({"ftdsnrat": 0.0 , "ftdhaird": 1, "ftdspit": 1, "ftdnose": 1})
+    assert nv.errors == {'ftdsnrat': ["('ftdsnrat', ['unallowed value 0.0']) for if {'ftdhaird': {'allowed': [1]}, 'ftdspit': {'allowed': [1]}, 'ftdnose': {'allowed': [1]}} then {'ftdsnrat': {'allowed': [88.88]}} - compatibility rule no: 3"]}

--- a/tests/test_rules_logic.py
+++ b/tests/test_rules_logic.py
@@ -218,6 +218,59 @@ def test_logic_count_exact(create_nacc_validator):
     assert not nv.validate({"count": 4, "var5": 1, "var4": None, "var3": None, "var2": 0, "var1": 0})
     assert nv.errors == {'count': ['error in formula evaluation - value 4 does not satisfy the specified formula']}
 
+def test_logic_count_exact_none(create_nacc_validator):
+    """ Test the count_exact logic rule against None """
+    schema = {
+        "var1": {"type": "integer", "nullable": True},
+        "var2": {"type": "integer", "nullable": True},
+        "var3": {"type": "integer", "nullable": True},
+        "var4": {"type": "integer", "nullable": True},
+        "var5": {"type": "integer", "nullable": True},
+        "count": {
+            "type": "integer",
+            "logic": {
+                "formula": {
+                    "==": [
+                        {
+                            "var": "count"
+                        },
+                        {
+                            "count_exact": [
+                                None,
+                                {"var": "var1"},
+                                {"var": "var2"},
+                                {"var": "var3"},
+                                {"var": "var4"},
+                                {"var": "var5"}
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    nv = create_nacc_validator(schema)
+
+    # valid case
+    assert nv.validate({"count": 5, "var1": None, "var2": None, "var3": None, "var4": None, "var5": None})
+    assert nv.validate({"count": 4, "var1": None, "var2": None, "var3": None, "var4": None, "var5": 1})
+    assert nv.validate({"count": 3, "var1": None, "var2": None, "var3": 0, "var4": None, "var5": 1})
+    assert nv.validate({"count": 0, "var1": 1, "var2": 2, "var3": 3, "var4": 4, "var5": 5})
+
+    # make sure it handles valid blank/null case
+    assert nv.validate({"count": 5})
+    assert nv.validate({"count": 2, "var5": 0, "var4": 1, "var3": 0})
+    assert nv.validate({"count": 2, "var5": 0, "var4": None, "var3": None, "var2": 0, "var1": 0})
+
+    # invalid cases
+    assert not nv.validate({"count": 5, "var1": 0, "var2": 0, "var3": 0, "var4": 0, "var5": 0})
+    assert nv.errors == {'count': ['error in formula evaluation - value 5 does not satisfy the specified formula']}
+    assert not nv.validate({"count": 5, "var1": None, "var2": 2, "var3": None, "var4": 4, "var5": None})
+    assert nv.errors == {'count': ['error in formula evaluation - value 5 does not satisfy the specified formula']}
+
+    assert not nv.validate({"count": 2, "var5": 1, "var2": 0, "var1": None})
+    assert nv.errors == {'count': ['error in formula evaluation - value 2 does not satisfy the specified formula']}
+
 def test_logic_count_exact_invalid_list(create_nacc_validator):
     """ Checking an error is thrown if not enough arguments are passed to count_exact """
     schema = {


### PR DESCRIPTION
Mostly just testing for weird situations, but also makes two algorithmic updates:

* Fixes issue where `datastore` was not being set for the temp validator in `_check_subschema_valid`, causing nested conditions with previous records to not evaluate correctly (e.g. A1 `EDUC` case, where `compare_with` previous record was nested inside a `temporalrules`)
    * Fix was to just assume any sub-validator will use the same datastore/primary_key and set it 
* Updates `compatibility` errors to be more verbose - before we were not reporting what the `then/else` conditions were and so it was impossible to tell what was wrong if a `then/else` condition failed. Unfortunately that does mean the error messages are longer/uglier though. 
    * Before there were also two COMPATIBILITY_FALSE and COMPATIBILITY_TRUE error messages that appeared to be the exact same thing, so I changed one of them to be COMPATIBILITY_ELSE to report when an else condition failed