### PR TITLE
ADCID validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Documentation of release versions of `nacc-form-validator`
 
 ## 0.4.0
 
+* Adds `_check_adcid` method to validate a provided ADCID against current list of ADCIDs. (Actual validation should be implemented by overriding the `is_valid_adcid` method in Datastore class)
 * Adds `get_previous_record` method to grab previous record from Datastore, which can grab the previous record or the previous record where a specific field is non-empty
 * Adds support for comparing against the previous record in `compare_with`
 * Adds new rule `compare_age` to handle rules that need to compare ages relative to a date
@@ -19,7 +20,7 @@ Documentation of release versions of `nacc-form-validator`
 
 ## 0.3.0
 
-* Adds `_check_with_rxnorm` function to check whether a given Drug ID is valid RXCUI code
+* Adds `_check_with_rxnorm` function to check whether a given Drug ID is valid RXCUI code. (Actual validation should be implemented by overriding the `is_valid_rxcui` method in Datastore class)
 * Updates `_validate_compare_with` to allow adjustments to be another field, and for base values to be hardcoded values
 * Updates json_logic `less` function to handle None
 * Updates `_validate_temporalrules` to iterate on multiple fields for `previous` and `current` clauses, remove `orderby` attribute

--- a/docs/data-quality-rule-definition-guidelines.md
+++ b/docs/data-quality-rule-definition-guidelines.md
@@ -919,26 +919,26 @@ If field `taxes` (difficulty with taxes, business, and other papers) is 0 (norma
 
 ### check_adcid
 
-Used to validate an ADCID is valid.
+Used to check whether a specified ADCID is valid.
 
-This function falls under the `function` rule which in turn calls the custom `check_adcid` rule in the NACCValidator. The rule definition should be in the following format:
+This validation is implemented using the `function` rule with custom `check_adcid` function in the NACCValidator. The rule definition should be in the following format:
 
 ```json
 {
     "<adcid_variable>": {
         "function": {
             "name": "check_adcid",
-            "args": {"own": "<bool, whether or not to check own ADCID or another center's ADCID; defaults to True>"}
+            "args": {"own": "<bool, whether to validate against own ADCID or list of current ADCIDs; defaults to True>"}
         }
     }
 }
 ```
 
-> **NOTE**: To validate `check_adcid`, the validator should have a `Datastore` instance which implements the `is_valid_adcid` function which will check if the given ADCID value is valid
+> **NOTE**: To validate `check_adcid`, the validator should have a `Datastore` instance which implements the `is_valid_adcid` function (which should have access to center's ADCID and the list of current ADCIDs).
 
 **Example:**
 
-The `adcid` must match the center's own ADCID, whereas `oldadcid` should be a valid ADCID but _not_ match its own. Which ADCIDs are valid is defined by the `Datastore` instance.
+The `adcid` must match the center's own ADCID, whereas `oldadcid` should be a valid ADCID in the current ADCIDs list. 
 
 <table>
 <tr>
@@ -957,7 +957,7 @@ oldadcid:
   function:
     name: check_adcid
     args:
-      - own: false
+      own: false
 </code></pre>
 </td>
 <td style="vertical-align:top;">

--- a/docs/data-quality-rule-definition-guidelines.md
+++ b/docs/data-quality-rule-definition-guidelines.md
@@ -12,6 +12,7 @@
     - [compatibility](#compatibility)
     - [logic](#logic)
     - [temporalrules](#temporalrules)
+    - [check\_adcid](#check_adcid)
     - [compute\_gds](#compute_gds)
     - [rxnorm](#rxnorm)
 
@@ -916,6 +917,77 @@ If field `taxes` (difficulty with taxes, business, and other papers) is 0 (norma
 </tr>
 </table>
 
+### check_adcid
+
+Used to validate an ADCID is valid.
+
+This function falls under the `function` rule which in turn calls the custom `check_adcid` rule in the NACCValidator. The rule definition should be in the following format:
+
+```json
+{
+    "<adcid_variable>": {
+        "function": {
+            "name": "check_adcid",
+            "args": {"own": "<bool, whether or not to check own ADCID or another center's ADCID; defaults to True>"}
+        }
+    }
+}
+```
+
+> **NOTE**: To validate `check_adcid`, the validator should have a `Datastore` instance which implements the `is_valid_adcid` function which will check if the given ADCID value is valid
+
+**Example:**
+
+The `adcid` must match the center's own ADCID, whereas `oldadcid` should be a valid ADCID but _not_ match its own. Which ADCIDs are valid is defined by the `Datastore` instance.
+
+<table>
+<tr>
+<th>YAML Rule Definition</th>
+<th>JSON Rule Definition</th>
+<th>When Validating</th>
+</tr>
+<tr>
+<td style="vertical-align:top;">
+<pre><code>adcid:
+  type: integer
+  function:
+    name: check_adcid
+oldadcid:
+  type: integer
+  function:
+    name: check_adcid
+    args:
+      - own: false
+</code></pre>
+</td>
+<td style="vertical-align:top;">
+<pre><code>{
+    "adcid": {
+        "type": "integer",
+        "function": {
+            "name": "check_adcid"
+        }
+    },
+    "oldadcid": {
+        "type": "integer",
+        "function": {
+            "name": "check_adcid",
+            "args": {"own": False}
+    }
+}
+</code></pre>
+</td>
+<td style="vertical-align:top;">
+<pre><code># assume the center's own ADCID is 0, and ADCIDs 0-5 inclusive are valid
+
+{"adcid": 0, "oldadcid": 5}   # passes
+{"adcid": 2, "oldadcid": 5}   # fails
+{"adcid": 0, "oldadcid": 9}   # fails
+</code></pre>
+</td>
+</tr>
+</table>
+
 ### compute_gds
 
 Custom rule defined to validate the Geriatric Depression Scale (GDS) score computation. Only be used for validating the `gds` field in UDS Form B6.
@@ -934,7 +1006,7 @@ The rule definition for `compute_gds` should follow the following format:
 
 Custom rule defined to check whether a given Drug ID is valid RXCUI code.
 
-This function uses the `check_with` rule from Cerberus. Rule definition should be in the following format:
+This function uses the `check_with` rule from Cerberus. The rule definition should be in the following format:
 
 ```json
 {

--- a/docs/validate_csv_records.py
+++ b/docs/validate_csv_records.py
@@ -10,7 +10,8 @@ import json
 import logging
 
 from pathlib import Path
-from nacc_form_validator import QualityCheck
+
+from nacc_form_validator.quality_check import QualityCheck
 
 logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger(__name__)
@@ -38,9 +39,11 @@ if __name__ == "__main__":
     log.info(f"strict mode::\t{not args.disable_strict}")
 
     if not args.rules_json.is_file():
-        raise FileNotFoundError(f"Cannot find specified rules JSON: {args.rules_json}")
+        raise FileNotFoundError(
+            f"Cannot find specified rules JSON: {args.rules_json}")
     if not args.input_records_csv.is_file():
-        raise FileNotFoundError(f"Cannot find specified input records CSV: {args.input_records_csv}")
+        raise FileNotFoundError(
+            f"Cannot find specified input records CSV: {args.input_records_csv}")
 
     """
     Instantiate the quality check object from rules JSON. This script assumes no datastore, and therefor
@@ -70,7 +73,8 @@ if __name__ == "__main__":
                 errors['row'] = i
                 all_errors.append(errors)
                 error_headers.update(set(errors.keys()))
-                log.warning(f"Row {i} in the input records CSV failed validation")
+                log.warning(
+                    f"Row {i} in the input records CSV failed validation")
 
     """
     Convert all_errors and error_headers to a "csv-like" dict for writing/printing out

--- a/nacc_form_validator/__init__.py
+++ b/nacc_form_validator/__init__.py
@@ -1,1 +1,1 @@
-from .quality_check import QualityCheck  # noqa: F401
+

--- a/nacc_form_validator/datastore.py
+++ b/nacc_form_validator/datastore.py
@@ -84,3 +84,17 @@ class Datastore(ABC):
             bool: True if provided drug ID is valid, else False
         """
         return False
+
+    @abstractmethod
+    def is_valid_adcid(self, adcid: int, own: bool) -> bool:
+        """Abstract method to check whether a given ADCID is valid. Override
+        this method to implement ADCID validation.
+
+        Args:
+            adcid: provided ADCID
+            own: whether to check own ADCID or another center's ADCID
+
+        Returns:
+            bool: True if provided ADCID is valid, else False
+        """
+        return False

--- a/nacc_form_validator/errors.py
+++ b/nacc_form_validator/errors.py
@@ -9,8 +9,11 @@ from cerberus.errors import (
     ValidationError,
 )
 
+from nacc_form_validator.quality_check import SchemaDefs
 
 # pylint: disable=(too-few-public-methods)
+
+
 class ErrorDefs:
     """Class to define custom errors."""
 
@@ -43,6 +46,8 @@ class ErrorDefs:
     COMPARE_AGE = ErrorDefinition(0x3002, 'compare_age')
     COMPARE_AGE_INVALID_COMPARISON = ErrorDefinition(0x3003, 'compare_age')
     TEMPORAL_SWAPPED = ErrorDefinition(0x3004, 'temporalrules')
+    ADCID_NOT_MATCH = ErrorDefinition(0x3005, "function")
+    ADCID_NOT_VALID = ErrorDefinition(0x3006, "function")
 
 
 class CustomErrorHandler(BasicErrorHandler):
@@ -124,6 +129,10 @@ class CustomErrorHandler(BasicErrorHandler):
             0x3004:
             "{1} for if {3} in current visit then {2} " +
             "in previous visit - temporal rule no: {0}",
+            0x3005:
+            "Provided ADCID {0} is not matching to your center's ADCID",
+            0x3006:
+            "Provided ADCID {0} is not in the valid list of ADCIDs",
         }
 
         self.messages.update(custom_errors)
@@ -145,41 +154,3 @@ class CustomErrorHandler(BasicErrorHandler):
                 return field + ": " + error_msg
 
         return super()._format_message(field, error)
-
-
-class SchemaDefs:
-    """Class to store schema attribute labels."""
-
-    TYPE = "type"
-    OP = "op"
-    IF_OP = "if_op"
-    THEN_OP = "then_op"
-    ELSE_OP = "else_op"
-    IF = "if"
-    THEN = "then"
-    ELSE = "else"
-    META = "meta"
-    ERRMSG = "errmsg"
-    ORDERBY = "orderby"
-    CONSTRAINTS = "constraints"
-    PREV_OP = "prev_op"
-    CURR_OP = "curr_op"
-    CURRENT = "current"
-    PREVIOUS = "previous"
-    CRR_DATE = "current_date"
-    CRR_YEAR = "current_year"
-    CRR_MONTH = "current_month"
-    CRR_DAY = "current_day"
-    PREV_RECORD = "previous_record"
-    FORMULA = "formula"
-    INDEX = "index"
-    FORMATTING = "formatting"
-    COMPARATOR = "comparator"
-    BASE = "base"
-    ADJUST = "adjustment"
-    IGNORE_EMPTY = "ignore_empty"
-    BIRTH_MONTH = 'birth_month'
-    BIRTH_DAY = 'birth_day'
-    BIRTH_YEAR = 'birth_year'
-    COMPARE_TO = "compare_to"
-    SWAP_ORDER = "swap_order"

--- a/nacc_form_validator/errors.py
+++ b/nacc_form_validator/errors.py
@@ -9,7 +9,7 @@ from cerberus.errors import (
     ValidationError,
 )
 
-from nacc_form_validator.quality_check import SchemaDefs
+from nacc_form_validator.keys import SchemaDefs
 
 # pylint: disable=(too-few-public-methods)
 

--- a/nacc_form_validator/errors.py
+++ b/nacc_form_validator/errors.py
@@ -130,7 +130,7 @@ class CustomErrorHandler(BasicErrorHandler):
             "{1} for if {3} in current visit then {2} " +
             "in previous visit - temporal rule no: {0}",
             0x3005:
-            "Provided ADCID {0} is not matching to your center's ADCID",
+            "Provided ADCID {0} does not match your center's ADCID",
             0x3006:
             "Provided ADCID {0} is not in the valid list of ADCIDs",
         }

--- a/nacc_form_validator/keys.py
+++ b/nacc_form_validator/keys.py
@@ -1,0 +1,41 @@
+"""Module for commonly used keys."""
+
+
+class SchemaDefs:
+    """Class to store JSON schema attribute labels."""
+
+    TYPE = "type"
+    OP = "op"
+    IF_OP = "if_op"
+    THEN_OP = "then_op"
+    ELSE_OP = "else_op"
+    IF = "if"
+    THEN = "then"
+    ELSE = "else"
+    META = "meta"
+    ERRMSG = "errmsg"
+    ORDERBY = "orderby"
+    CONSTRAINTS = "constraints"
+    PREV_OP = "prev_op"
+    CURR_OP = "curr_op"
+    CURRENT = "current"
+    PREVIOUS = "previous"
+    CRR_DATE = "current_date"
+    CRR_YEAR = "current_year"
+    CRR_MONTH = "current_month"
+    CRR_DAY = "current_day"
+    PREV_RECORD = "previous_record"
+    FORMULA = "formula"
+    INDEX = "index"
+    FORMATTING = "formatting"
+    COMPARATOR = "comparator"
+    BASE = "base"
+    ADJUST = "adjustment"
+    IGNORE_EMPTY = "ignore_empty"
+    BIRTH_MONTH = 'birth_month'
+    BIRTH_DAY = 'birth_day'
+    BIRTH_YEAR = 'birth_year'
+    COMPARE_TO = "compare_to"
+    SWAP_ORDER = "swap_order"
+    FUNCTION_NAME = 'name'
+    FUNCTION_ARGS = 'args'

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -12,7 +12,7 @@ from nacc_form_validator import utils
 from nacc_form_validator.datastore import Datastore
 from nacc_form_validator.errors import CustomErrorHandler, ErrorDefs
 from nacc_form_validator.json_logic import jsonLogic
-from nacc_form_validator.quality_check import SchemaDefs
+from nacc_form_validator.keys import SchemaDefs
 
 log = logging.getLogger(__name__)
 
@@ -823,7 +823,7 @@ class NACCValidator(Validator):
             function.get(SchemaDefs.FUNCTION_NAME, 'undefined')
         func = getattr(self, function_name, None)
         if func and callable(func):
-            kwargs = getattr(self, function.get(SchemaDefs.FUNCTION_ARGS), {})
+            kwargs = function.get(SchemaDefs.FUNCTION_ARGS, {})
             func(field, value, **kwargs)
         else:
             err_msg = f"{function_name} not defined in the validator module"

--- a/nacc_form_validator/quality_check.py
+++ b/nacc_form_validator/quality_check.py
@@ -6,51 +6,8 @@ from cerberus.errors import DocumentErrorTree
 from cerberus.schema import SchemaError
 
 from nacc_form_validator.datastore import Datastore
-from nacc_form_validator.nacc_validator import (
-    CustomErrorHandler,
-    NACCValidator,
-    ValidationException,
-)
-
-
-class SchemaDefs:
-    """Class to store schema attribute labels."""
-
-    TYPE = "type"
-    OP = "op"
-    IF_OP = "if_op"
-    THEN_OP = "then_op"
-    ELSE_OP = "else_op"
-    IF = "if"
-    THEN = "then"
-    ELSE = "else"
-    META = "meta"
-    ERRMSG = "errmsg"
-    ORDERBY = "orderby"
-    CONSTRAINTS = "constraints"
-    PREV_OP = "prev_op"
-    CURR_OP = "curr_op"
-    CURRENT = "current"
-    PREVIOUS = "previous"
-    CRR_DATE = "current_date"
-    CRR_YEAR = "current_year"
-    CRR_MONTH = "current_month"
-    CRR_DAY = "current_day"
-    PREV_RECORD = "previous_record"
-    FORMULA = "formula"
-    INDEX = "index"
-    FORMATTING = "formatting"
-    COMPARATOR = "comparator"
-    BASE = "base"
-    ADJUST = "adjustment"
-    IGNORE_EMPTY = "ignore_empty"
-    BIRTH_MONTH = 'birth_month'
-    BIRTH_DAY = 'birth_day'
-    BIRTH_YEAR = 'birth_year'
-    COMPARE_TO = "compare_to"
-    SWAP_ORDER = "swap_order"
-    FUNCTION_NAME = 'name'
-    FUNCTION_ARGS = 'args'
+from nacc_form_validator.errors import CustomErrorHandler
+from nacc_form_validator.nacc_validator import NACCValidator, ValidationException
 
 
 class QualityCheckException(Exception):

--- a/nacc_form_validator/quality_check.py
+++ b/nacc_form_validator/quality_check.py
@@ -13,6 +13,46 @@ from nacc_form_validator.nacc_validator import (
 )
 
 
+class SchemaDefs:
+    """Class to store schema attribute labels."""
+
+    TYPE = "type"
+    OP = "op"
+    IF_OP = "if_op"
+    THEN_OP = "then_op"
+    ELSE_OP = "else_op"
+    IF = "if"
+    THEN = "then"
+    ELSE = "else"
+    META = "meta"
+    ERRMSG = "errmsg"
+    ORDERBY = "orderby"
+    CONSTRAINTS = "constraints"
+    PREV_OP = "prev_op"
+    CURR_OP = "curr_op"
+    CURRENT = "current"
+    PREVIOUS = "previous"
+    CRR_DATE = "current_date"
+    CRR_YEAR = "current_year"
+    CRR_MONTH = "current_month"
+    CRR_DAY = "current_day"
+    PREV_RECORD = "previous_record"
+    FORMULA = "formula"
+    INDEX = "index"
+    FORMATTING = "formatting"
+    COMPARATOR = "comparator"
+    BASE = "base"
+    ADJUST = "adjustment"
+    IGNORE_EMPTY = "ignore_empty"
+    BIRTH_MONTH = 'birth_month'
+    BIRTH_DAY = 'birth_day'
+    BIRTH_YEAR = 'birth_year'
+    COMPARE_TO = "compare_to"
+    SWAP_ORDER = "swap_order"
+    FUNCTION_NAME = 'name'
+    FUNCTION_ARGS = 'args'
+
+
 class QualityCheckException(Exception):
     """Raised if something goes wrong while loading rule definitions."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,8 @@ Utility/helper methods and fixtures used for testing.
 """
 import pytest
 
-from dateutil import parser
-from nacc_form_validator.nacc_validator import NACCValidator, CustomErrorHandler
+from nacc_form_validator.nacc_validator import NACCValidator
+from nacc_form_validator. errors import CustomErrorHandler
 
 
 @pytest.fixture(scope="session")
@@ -15,6 +15,7 @@ def create_nacc_validator():
                              allow_unknown=False,
                              error_handler=CustomErrorHandler(schema))
     return _create_nacc_validator
+
 
 @pytest.fixture
 def nv(create_nacc_validator):
@@ -48,6 +49,7 @@ def nv(create_nacc_validator):
     }
 
     return create_nacc_validator(schema)
+
 
 @pytest.fixture(scope="session")
 def date_constraint():

--- a/tests/test_nacc_validator_datastore.py
+++ b/tests/test_nacc_validator_datastore.py
@@ -402,7 +402,7 @@ def test_check_adcid():
     assert nv.validate({"oldadcid": 10})
     assert not nv.validate({"adcid": 1})
     assert nv.errors == {
-        'adcid': ["Provided ADCID 1 is not matching to your center's ADCID"]}
+        'adcid': ["Provided ADCID 1 does not match your center's ADCID"]}
     assert not nv.validate({"oldadcid": 20})
     assert nv.errors == {
         'oldadcid': ["Provided ADCID 20 is not in the valid list of ADCIDs"]}

--- a/tests/test_rules_cerberus.py
+++ b/tests/test_rules_cerberus.py
@@ -136,3 +136,27 @@ def test_date_format(date_constraint, create_nacc_validator):
     assert nv.errors == {'frmdate': [f"value does not match regex '{date_constraint}'"]}
     assert not nv.validate({'frmdate': 'hello world'})
     assert nv.errors == {'frmdate': [f"value does not match regex '{date_constraint}'"]}
+
+
+def test_allowed(create_nacc_validator):
+    """ Test allowed with strings. """
+    schema = {
+        "testvar": {
+            "allowed": [
+                1,
+                'hello'
+            ]
+        }
+    }
+
+    nv = create_nacc_validator(schema)
+
+    assert nv.validate({'testvar': 1})
+    assert nv.validate({'testvar': 'hello'})
+
+    assert not nv.validate({'testvar': 2})
+    assert nv.errors == {'testvar': ['unallowed value 2']}
+    assert not nv.validate({'testvar': '1'})
+    assert nv.errors == {'testvar': ['unallowed value 1']}
+    assert not nv.validate({'testvar': 'hell0'})
+    assert nv.errors == {'testvar': ['unallowed value hell0']}


### PR DESCRIPTION
- Add support for dynamic ADCID validation
- Uses `function` rule => check `_validate_function` method in NACCvalidator

Example schema
```
schema = {
        "adcid": {
            "type": "integer",
            "function": {
                "name": "check_adcid"
            }
        },
        "oldadcid": {
            "type": "integer",
            "function": {
                "name": "check_adcid",
                "args": {"own": False}
            }
        }
    }
```

- `_check_adcid` function uses Datastore class to do the actual validation.
- Add abstract method `is_valid_adcid` to Datastore class (needs to be implemented in form-qc-checker gear)
- Update tests