### PR TITLE
Add support for checking against initial visit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 Documentation of release versions of `nacc-form-validator`
 
-## Unreleased
+## 0.6.0
 
+* Adds support for grabbing the initial record
 * Refactors `utils.compare_values` and validation of min/max
 * Reformats repo to pass `pants lint ::` and `pants check ::`
 * Updates lockfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Documentation of release versions of `nacc-form-validator`
 
 ## 0.6.0
 
-* Adds support for grabbing the initial record
+* Adds support for comparaing against the initial record
 * Refactors `utils.compare_values` and validation of min/max
 * Reformats repo to pass `pants lint ::` and `pants check ::`
 * Updates lockfile

--- a/nacc_form_validator/BUILD
+++ b/nacc_form_validator/BUILD
@@ -7,7 +7,7 @@ python_distribution(
     sdist=True,
     provides=python_artifact(
         name="nacc-form-validator",
-        version="0.5.3",
+        version="0.6.0",
         description="The NACC form validator package",
         author="NACC",
         author_email="nacchelp@uw.edu",

--- a/nacc_form_validator/datastore.py
+++ b/nacc_form_validator/datastore.py
@@ -71,11 +71,13 @@ class Datastore(ABC):
         return None
 
     @abstractmethod
-    def get_initial_record(self,
-                           current_record: Dict[str, Any],
-                           ignore_empty_fields: List[str]) -> Optional[Dict[str, Any]]:
-        """Abstract method to return the initial record. Override this
-        method to retrieve the records from the desired datastore/warehouse.
+    def get_initial_record(
+        self,
+        current_record: Dict[str, Any],
+        ignore_empty_fields: Optional[List[str]] = None
+    ) -> Optional[Dict[str, Any]]:
+        """Abstract method to return the initial record. Override this method
+        to retrieve the records from the desired datastore/warehouse.
 
         Args:
             current_record: Record currently being validated

--- a/nacc_form_validator/datastore.py
+++ b/nacc_form_validator/datastore.py
@@ -56,17 +56,34 @@ class Datastore(ABC):
     @abstractmethod
     def get_previous_nonempty_record(
             self, current_record: Dict[str, Any],
-            fields: List[str]) -> Optional[Dict[str, Any]]:
+            ignore_empty_fields: List[str]) -> Optional[Dict[str, Any]]:
         """Abstract method to return the previous record where all fields are
         NOT empty for the specified participant. Override this method to
         retrieve the records from the desired datastore/warehouse.
 
         Args:
             current_record: Record currently being validated
-            fields: Field(s) to check for non-empty values
+            ignore_empty_fields: Field(s) to check for non-empty values
 
         Returns:
             Dict[str, Any]: Previous nonempty record or None if none found
+        """
+        return None
+
+    @abstractmethod
+    def get_initial_record(self,
+                           current_record: Dict[str, Any],
+                           ignore_empty_fields: List[str]) -> Optional[Dict[str, Any]]:
+        """Abstract method to return the initial record. Override this
+        method to retrieve the records from the desired datastore/warehouse.
+
+        Args:
+            current_record: Record currently being validated
+            ignore_empty_fields: Field(s) to check for non-empty values
+
+        Returns:
+            Dict[str, str]: Initial record or None if no initial record found
+            or current record is the initial record
         """
         return None
 

--- a/nacc_form_validator/errors.py
+++ b/nacc_form_validator/errors.py
@@ -98,12 +98,12 @@ class CustomErrorHandler(BasicErrorHandler):
             0x1009:
             "{1} for if {2} else {3} - compatibility rule no: {0}",
             0x2000:
-            "{1} for if {2} in previous visit then {3} " +
+            "{1} for if {2} in {4} visit then {3} " +
             "in current visit - temporal rule no: {0}",
             0x2001:
             "primary key variable {0} not set in current visit data",
             0x2002:
-            "failed to retrieve the previous visit, cannot proceed with " +
+            "failed to retrieve the {0} visit, cannot proceed with " +
             "validation",
             0x2003:
             "error in formula evaluation - {0}",
@@ -124,7 +124,7 @@ class CustomErrorHandler(BasicErrorHandler):
             0x2009:
             "input value doesn't satisfy the condition {0}",
             0x3000:
-            "failed to retrieve record for previous visit, cannot proceed " +
+            "failed to retrieve record for {1} visit, cannot proceed " +
             "with validation {0}",
             0x3001:
             "Drug ID {0} is not a valid RXCUI",
@@ -136,7 +136,7 @@ class CustomErrorHandler(BasicErrorHandler):
             "Error in comparing {0} to age at {1} ({2}): {3}",
             0x3005:
             "{1} for if {3} in current visit then {2} " +
-            "in previous visit - temporal rule no: {0}",
+            "in {4} visit - temporal rule no: {0}",
             0x3006:
             "Provided ADCID {0} does not match your center's ADCID",
             0x3007:

--- a/nacc_form_validator/keys.py
+++ b/nacc_form_validator/keys.py
@@ -39,3 +39,4 @@ class SchemaDefs:
     SWAP_ORDER = "swap_order"
     FUNCTION_NAME = "name"
     FUNCTION_ARGS = "args"
+    INITIAL_RECORD = 'initial_record'

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -268,14 +268,15 @@ class NACCValidator(Validator):
         # Grab previous record
         prev_ins = (
             self.__datastore.get_previous_nonempty_record(  # type: ignore
-                self.document, ignore_empty_fields) if ignore_empty_fields
-            else self.__datastore.get_previous_record(self.document))
+                self.document, ignore_empty_fields) if ignore_empty_fields else
+            self.__datastore.get_previous_record(self.document)
+        )  # type: ignore
 
         if prev_ins:
             prev_ins = self.cast_record(prev_ins)
 
         if not ignore_empty_fields:
-            self.__prev_records[record_id] = prev_ins
+            self.__prev_records[record_id] = prev_ins  # type: ignore
 
         return prev_ins
 
@@ -297,10 +298,10 @@ class NACCValidator(Validator):
         # only evaluate if we have not already cached the initial record
         if self.__initial_record is None:
             if not self.__ensure_datastore_set(field):
-                return None
-
-            self.__initial_record = self.__datastore.get_initial_record(
-                self.document, ignore_empty_fields)
+                self.__initial_record = {}
+            else:
+                self.__initial_record = self.__datastore.get_initial_record(  # type: ignore
+                    self.document, ignore_empty_fields)
 
         return self.__initial_record
 
@@ -1023,13 +1024,15 @@ class NACCValidator(Validator):
         initial_record = comparison.get(SchemaDefs.INITIAL_RECORD, False)
 
         if prev_record and initial_record:
-            err_msg = ("Cannot specify both prev_record and initial_record for "
-                + "comparison rule")
+            err_msg = (
+                "Cannot specify both prev_record and initial_record for " +
+                "comparison rule")
             self.__add_system_error(field, err_msg)
             raise ValidationException(err_msg)
 
         visit_type = "previous" if not initial_record else "initial"
-        base_str = f"{base} ({visit_type} record)" if (prev_record or initial_record) else base
+        base_str = f"{base} ({visit_type} record)" if (
+            prev_record or initial_record) else base
         comparison_str = f"{field} {comparator} {base_str}"
         if adjustment and operator:
             if operator == "abs":
@@ -1039,7 +1042,8 @@ class NACCValidator(Validator):
 
         if prev_record or initial_record:
             ignore_empty_fields = [base] if ignore_empty else None
-            func = self.__get_previous_record if prev_record else self.__get_initial_record
+            func = self.__get_previous_record if prev_record \
+                else self.__get_initial_record
             record = func(field=base, ignore_empty_fields=ignore_empty_fields)
 
             # pass through validation if no records found and ignore_empty is True

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -269,8 +269,8 @@ class NACCValidator(Validator):
         prev_ins = (
             self.__datastore.get_previous_nonempty_record(  # type: ignore
                 self.document, ignore_empty_fields) if ignore_empty_fields else
-            self.__datastore.get_previous_record(self.document)
-        )  # type: ignore
+            self.__datastore.get_previous_record(self.document)  # type: ignore
+        )
 
         if prev_ins:
             prev_ins = self.cast_record(prev_ins)

--- a/tests/test_nacc_validator_datastore.py
+++ b/tests/test_nacc_validator_datastore.py
@@ -66,7 +66,7 @@ class CustomDatastore(Datastore):
 
     def get_previous_nonempty_record(
             self, current_record: dict[str, str],
-            fields: list[str]) -> dict[str, str] | None:
+            ignore_empty_fields: list[str]) -> dict[str, str] | None:
         """Grabs the previous record where field is not empty."""
         key = current_record[self.pk_field]
         if key not in self.__db:
@@ -75,7 +75,7 @@ class CustomDatastore(Datastore):
         sorted_record = []
         for x in self.__db[key]:
             nonempty = True
-            for f in fields:
+            for f in ignore_empty_fields:
                 if x.get(f, None) is None:  # type: ignore
                     nonempty = False
             if nonempty:
@@ -87,6 +87,15 @@ class CustomDatastore(Datastore):
 
         index = sorted_record.index(current_record)
         return sorted_record[index - 1] if index != 0 else None  # type: ignore
+
+    def get_initial_record(
+            self, current_record: dict[str, str],
+            ignore_empty_fields: list[str]) -> dict[str, str] | None:
+        """Grabs the initial record."""
+        if self.__db.get(key, None):
+            return self.__db[key][0]
+
+        return None
 
     def is_valid_rxcui(self, drugid: int) -> bool:
         """For RXCUI testing."""

--- a/tests/test_nacc_validator_datastore.py
+++ b/tests/test_nacc_validator_datastore.py
@@ -546,8 +546,8 @@ def test_compare_with_initial_visit():
 
     assert nv.errors == {
         'birthdy': [
-            "input value doesn't satisfy the condition "
-            + "birthdy == birthdy (initial record)"
+            "input value doesn't satisfy the condition " +
+            "birthdy == birthdy (initial record)"
         ]
     }
 


### PR DESCRIPTION
Adds support for checking agains the initial visit, which essentially just leverages what `previous_record` checks were already doing. Can separate out to its own rule if you think it's worth it to.

WIP/draft for adding it to qc-form-checker gear: https://github.com/naccdata/flywheel-gear-extensions/pull/278