### PR TITLE
Fix temporalrule date issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Documentation of release versions of `nacc-form-validator`
 ## Unreleased
 
 * Refactors `utils.compare_values` and validation of min/max
+* Fixes issue where `"max": "current_year"` does not work when evaluated inside temporalrules (dtype not set on prev record so need to specify)
 * Reformats repo to pass `pants lint ::` and `pants check ::`
 * Updates lockfile
 

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -333,9 +333,12 @@ class NACCValidator(Validator):
         if value is None:
             super()._drop_remaining_rules("compare_age")
 
-    def _convert_value_to_date(self, target_value: object, field: str,
+    def _convert_value_to_date(self,
+                               target_value: object,
+                               field: str,
                                value: object,
-                               error_def: ErrorDefs) -> Optional[date]:
+                               error_def: ErrorDefs,
+                               default_dtype: str = 'undefined') -> Optional[date]:
         """Converts the given value to a date object.
 
         Args:
@@ -343,8 +346,9 @@ class NACCValidator(Validator):
             field: Variable name
             value: Variable value
             error_def: The ErrorDef to raise on error
+            dtype: dtype to use if undefined
         """
-        dtype = self.dtypes[field] if field in self.dtypes else "undefined"
+        dtype = self.dtypes[field] if field in self.dtypes else default_dtype
         try:
             if dtype == "str":
                 return utils.convert_to_date(value)
@@ -411,8 +415,9 @@ class NACCValidator(Validator):
             {'nullable': False}
         """
         if max_value in (SchemaDefs.CRR_DATE, SchemaDefs.CRR_YEAR):
+            dtype = 'int' if max_value == SchemaDefs.CRR_YEAR else 'date'
             input_date = self._convert_value_to_date(
-                max_value, field, value, ErrorDefs.INVALID_DATE_MAX)
+                max_value, field, value, ErrorDefs.INVALID_DATE_MAX, default_dtype=dtype)
             if not input_date:
                 return
 
@@ -443,8 +448,9 @@ class NACCValidator(Validator):
         """
 
         if min_value in (SchemaDefs.CRR_DATE, SchemaDefs.CRR_YEAR):
+            dtype = 'int' if min_value == SchemaDefs.CRR_YEAR else 'date'
             input_date = self._convert_value_to_date(
-                min_value, field, value, ErrorDefs.INVALID_DATE_MIN)
+                min_value, field, value, ErrorDefs.INVALID_DATE_MIN, default_dtype=dtype)
             if not input_date:
                 return
 

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -333,12 +333,13 @@ class NACCValidator(Validator):
         if value is None:
             super()._drop_remaining_rules("compare_age")
 
-    def _convert_value_to_date(self,
-                               target_value: object,
-                               field: str,
-                               value: object,
-                               error_def: ErrorDefs,
-                               default_dtype: str = 'undefined') -> Optional[date]:
+    def _convert_value_to_date(
+            self,
+            target_value: object,
+            field: str,
+            value: object,
+            error_def: ErrorDefs,
+            default_dtype: str = 'undefined') -> Optional[date]:
         """Converts the given value to a date object.
 
         Args:
@@ -417,7 +418,11 @@ class NACCValidator(Validator):
         if max_value in (SchemaDefs.CRR_DATE, SchemaDefs.CRR_YEAR):
             dtype = 'int' if max_value == SchemaDefs.CRR_YEAR else 'date'
             input_date = self._convert_value_to_date(
-                max_value, field, value, ErrorDefs.INVALID_DATE_MAX, default_dtype=dtype)
+                max_value,
+                field,
+                value,
+                ErrorDefs.INVALID_DATE_MAX,
+                default_dtype=dtype)
             if not input_date:
                 return
 
@@ -450,7 +455,11 @@ class NACCValidator(Validator):
         if min_value in (SchemaDefs.CRR_DATE, SchemaDefs.CRR_YEAR):
             dtype = 'int' if min_value == SchemaDefs.CRR_YEAR else 'date'
             input_date = self._convert_value_to_date(
-                min_value, field, value, ErrorDefs.INVALID_DATE_MIN, default_dtype=dtype)
+                min_value,
+                field,
+                value,
+                ErrorDefs.INVALID_DATE_MIN,
+                default_dtype=dtype)
             if not input_date:
                 return
 

--- a/tests/test_nacc_validator_datastore.py
+++ b/tests/test_nacc_validator_datastore.py
@@ -542,3 +542,58 @@ def test_check_adcid():
     assert nv.errors == {
         "oldadcid": ["Provided ADCID 20 is not in the valid list of ADCIDs"]
     }
+
+def test_temporal_check_current_year():
+    """Test temporal check with current year
+    """
+    schema = {
+        "patient_id": {
+            "type": "string"
+        },
+        "visit_num": {
+            "type": "integer"
+        },
+        "birthyr": {
+            "type": "integer",
+            "temporalrules": [{
+                "index": 0,
+                "previous": {
+                    "birthyr": {
+                        "min": 0,
+                        "max": "current_year"
+                    }
+                },
+                "current": {
+                    "birthyr": {
+                        "compare_with": {
+                            "comparator": "==",
+                            "base": "birthyr",
+                            "previous_record": True
+                        }
+                    }
+                },
+            }],
+        },
+    }
+
+    nv = create_nacc_validator_with_ds(schema, "patient_id", "visit_num")
+
+    assert nv.validate({
+        "patient_id": "PatientID1",
+        "visit_num": 4,
+        "birthyr": 1950
+    })
+
+    assert not nv.validate({
+        "patient_id": "PatientID1",
+        "visit_num": 4,
+        "birthyr": 1949
+    })
+    assert nv.errors == {
+    'birthyr': ['(\'birthyr\', ["input value doesn\'t satisfy the condition '
+        'birthyr == birthyr (previous record)"]) for if {\'birthyr\': '
+        "{'min': 0, 'max': 'current_year'}} in previous visit then "
+        "{'birthyr': {'compare_with': {'comparator': '==', 'base': "
+        "'birthyr', 'previous_record': True}}} in current visit - "
+        'temporal rule no: 0']
+    }

--- a/tests/test_nacc_validator_datastore.py
+++ b/tests/test_nacc_validator_datastore.py
@@ -543,9 +543,9 @@ def test_check_adcid():
         "oldadcid": ["Provided ADCID 20 is not in the valid list of ADCIDs"]
     }
 
+
 def test_temporal_check_current_year():
-    """Test temporal check with current year
-    """
+    """Test temporal check with current year."""
     schema = {
         "patient_id": {
             "type": "string"
@@ -554,7 +554,8 @@ def test_temporal_check_current_year():
             "type": "integer"
         },
         "birthyr": {
-            "type": "integer",
+            "type":
+            "integer",
             "temporalrules": [{
                 "index": 0,
                 "previous": {
@@ -590,10 +591,12 @@ def test_temporal_check_current_year():
         "birthyr": 1949
     })
     assert nv.errors == {
-    'birthyr': ['(\'birthyr\', ["input value doesn\'t satisfy the condition '
-        'birthyr == birthyr (previous record)"]) for if {\'birthyr\': '
-        "{'min': 0, 'max': 'current_year'}} in previous visit then "
-        "{'birthyr': {'compare_with': {'comparator': '==', 'base': "
-        "'birthyr', 'previous_record': True}}} in current visit - "
-        'temporal rule no: 0']
+        'birthyr': [
+            '(\'birthyr\', ["input value doesn\'t satisfy the condition '
+            'birthyr == birthyr (previous record)"]) for if {\'birthyr\': '
+            "{'min': 0, 'max': 'current_year'}} in previous visit then "
+            "{'birthyr': {'compare_with': {'comparator': '==', 'base': "
+            "'birthyr', 'previous_record': True}}} in current visit - "
+            'temporal rule no: 0'
+        ]
     }


### PR DESCRIPTION
Fixes issue where `"max": "current_year"` does not work when evaluated inside temporalrules (dtype not set on prev record so need to specify)