### PR TITLE
Revise pulling initial visit packet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Documentation of release versions of `nacc-form-validator`
 
 ## 0.6.0
 
+* Adds abstract method for pulling UDS IVP packets to Datastore
 * Adds support for comparaing against the initial record
 * Refactors `utils.compare_values` and validation of min/max
 * Fixes issue where `"max": "current_year"` does not work when evaluated inside temporalrules (dtype not set on prev record so need to specify)

--- a/docs/data-quality-rule-definition-guidelines.md
+++ b/docs/data-quality-rule-definition-guidelines.md
@@ -11,7 +11,9 @@
     - [compare\_age](#compare_age)
     - [compatibility](#compatibility)
     - [logic](#logic)
+      - [Custom Operations](#custom-operations)
     - [temporalrules](#temporalrules)
+- [{"visit\_date": 1, "taxes": 0}](#visit_date-1-taxes-0)
     - [check\_adcid](#check_adcid)
     - [compute\_gds](#compute_gds)
     - [rxnorm](#rxnorm)
@@ -262,6 +264,7 @@ Used to validate the field based on comparison with another field, with optional
 * `initial_record`: Optional boolean - if True, will search for `base` in the initial record and make the comparison against that
     * Error will be thrown if both `initial_record` and `previous_record` are set to True
 * `ignore_empty`: Optional boolean - if comparing to previous record(s), set this to True to ignore records where the specified `base` is empty
+    * Not applicable for `initial_record`, error will be thrown if `initial_record` True and `ignore_empty` fiels are provided
     * If this is set to True, the validation will _ignore_ cases when a previous record was not found (e.g. pass through validation without errors)
 
 The value to compare to (`base`) can be another field in the schema OR a special keywords either related to the current date (i.e. the exact time/date at time of validation) or a previous record
@@ -283,7 +286,7 @@ The rule definition for `compare_with` should follow the following format:
             "op": "(optional) operation, one of +, -, *, /, abs",
             "previous_record": "(optional) boolean, whether or not to compare to base in the previous record",
             "initial_record": "(optional) boolean, whether or not to compare to base in the initial record",
-            "ignore_empty": "(optional) boolean, whether or not to ignore previous/initial records where this field is empty"
+            "ignore_empty": "(optional) boolean, whether or not to ignore previous records where this field is empty"
         }
 }
 ```
@@ -803,9 +806,9 @@ var3:
 
 The validator also has custom operators in addition to the ones provided by json-logic-py:
 
-| Operator | Arguments | Description |
-| -------- | --------- | ----------- |
-| `count` | `[var1, var2, var3...]` | Counts how many valid variables are in the list, ignoring null and 0 values |
+| Operator      | Arguments                       | Description                                                                                                                                                                               |
+| ------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `count`       | `[var1, var2, var3...]`         | Counts how many valid variables are in the list, ignoring null and 0 values                                                                                                               |
 | `count_exact` | `[base, var1, var2, var3, ...]` | Counts how many values in the list equal the base. The first value is always considered the base, and the rest of the list is compared to it, so this operator requires at least 2 items. |
 
 
@@ -820,9 +823,9 @@ Each constraint also has optional fields that can be set:
 * Each `previous/current` attribute can have several fields which need to be satisifed, so an optional `*_op` attribute can be used to specify the boolean operation in which to compare the different fields. For example, if `prev_op = or`, then as long as _any_ of the fields satsify their schema, the `current` attribute will be evaluated. The default `*_op` is `and`.
 * `initial_record`: If set to True, will grab the initial record (not necessarily the previous one)
 * `ignore_empty`: Takes a string or list of strings denoting fields that cannot be empty
+    * Not applicable for `initial_record`, error will be thrown if `initial_record` True and `ignore_empty` fields are provided
     * When grabbing the previous record, the validator will grab the first previous record where _all_ specified fields are non-empty.
-    * When grabbing the initial record, will just return None if _all_ specified fields are empty.
-    * If no record is found that satisfies all fields being non-empty, the validator will _ignore_ the check (e.g. pass through validation without errors)
+      * If no record is found that satisfies all fields being non-empty, the validator will _ignore_ the check (e.g. pass through validation without errors)
 * `swap_order`: If set to True, it will swap the order of operations, evluating the `current` subschema first, then the `previous` subschema
 
 > **NOTE**: To validate `temporalrules`, the validator should have a `Datastore` instance which will be used to retrieve the previous visit record(s) for the participant. 

--- a/nacc_form_validator/datastore.py
+++ b/nacc_form_validator/datastore.py
@@ -72,10 +72,7 @@ class Datastore(ABC):
 
     @abstractmethod
     def get_initial_record(
-        self,
-        current_record: Dict[str, Any],
-        ignore_empty_fields: Optional[List[str]] = None
-    ) -> Optional[Dict[str, Any]]:
+            self, current_record: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Abstract method to return the initial record. Override this method
         to retrieve the record from the desired datastore/warehouse.
 
@@ -84,7 +81,6 @@ class Datastore(ABC):
 
         Args:
             current_record: Record currently being validated
-            ignore_empty_fields: Field(s) to check for non-empty values
 
         Returns:
             Dict[str, str]: Initial record or None if no initial record found

--- a/nacc_form_validator/datastore.py
+++ b/nacc_form_validator/datastore.py
@@ -77,7 +77,10 @@ class Datastore(ABC):
         ignore_empty_fields: Optional[List[str]] = None
     ) -> Optional[Dict[str, Any]]:
         """Abstract method to return the initial record. Override this method
-        to retrieve the records from the desired datastore/warehouse.
+        to retrieve the record from the desired datastore/warehouse.
+
+        Note: Return the IVP packet for the modules that has only one initial packet,
+        else return the first record sorted by visit date or form date.
 
         Args:
             current_record: Record currently being validated
@@ -85,7 +88,21 @@ class Datastore(ABC):
 
         Returns:
             Dict[str, str]: Initial record or None if no initial record found
-            or current record is the initial record
+        """
+        return None
+
+    @abstractmethod
+    def get_uds_ivp_record(
+            self, current_record: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Abstract method to return the UDS IVP record for the particiapnt.
+        Override this method to retrieve the record from the desired
+        datastore/warehouse.
+
+        Args:
+            current_record: Record currently being validated
+
+        Returns:
+            Dict[str, str]: UDS IVP record or None if no UDS IVP found
         """
         return None
 

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -311,8 +311,8 @@ class NACCValidator(Validator):
         if record_id in self.__initial_records:
             return self.__initial_records[record_id]
 
-        initital_record = self.__datastore.get_initial_record(
-            self.document)  # type: ignore
+        initital_record = self.__datastore.get_initial_record(  # type: ignore
+            self.document)
         if initital_record:
             initital_record = self.cast_record(initital_record)
             self.__initial_records[record_id] = initital_record

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -290,7 +290,9 @@ class NACCValidator(Validator):
         field: str,
         ignore_empty_fields: Optional[List[str]] = None,
     ) -> Optional[Dict[str, Dict[str, Any]]]:
-        """Get the initial record from the Datastore.
+        """Get the initial record from the Datastore. Returns IVP packet for
+        the modules that has initial and follwup packets, else the first record
+        sorted by visit date or form date.
 
         Args:
             field: Variable name

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -311,7 +311,8 @@ class NACCValidator(Validator):
         if record_id in self.__initial_records:
             return self.__initial_records[record_id]
 
-        initital_record = self.__datastore.get_initial_record(self.document)
+        initital_record = self.__datastore.get_initial_record(
+            self.document)  # type: ignore
         if initital_record:
             initital_record = self.cast_record(initital_record)
             self.__initial_records[record_id] = initital_record

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -215,13 +215,17 @@ class NACCValidator(Validator):
 
         return record
 
-    def __ensure_datastore_set(self, field: str) -> Optional[str]:
+    def __ensure_datastore_set(self, field: str) -> bool:
         """Ensure the datastore is properly set.
 
         Args:
             field: Variable name
+
         Returns:
-            The record ID, if datastore properly set
+            True, if datastore properly set, else False
+
+        Raises:
+            ValidationException: If Datastore or primary key not set
         """
         if not self.__datastore:
             err_msg = "Datastore not set, cannot validate temporal rules"
@@ -236,9 +240,9 @@ class NACCValidator(Validator):
         if self.primary_key not in self.document or not self.document[
                 self.primary_key]:
             self._error(field, ErrorDefs.NO_PRIMARY_KEY, self.primary_key)
-            return None
+            return False
 
-        return self.document[self.primary_key]
+        return True
 
     def __get_previous_record(
         self,
@@ -256,9 +260,10 @@ class NACCValidator(Validator):
         Returns:
             Dict[str, object]: Casted record Dict[field, value]
         """
-        record_id = self.__ensure_datastore_set(field)
-        if not record_id:
+        if not self.__ensure_datastore_set(field):
             return None
+
+        record_id = self.document[self.primary_key]
 
         # If the previous record was already retrieved and not ignore_empty_fields,
         # use it. Similarly only save into cache if ignore_empty_fields is None/empty

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -392,7 +392,7 @@ class NACCValidator(Validator):
             field: Variable name
             value: Variable value
             error_def: The ErrorDef to raise on error
-            dtype: dtype to use if undefined
+            default_dtype: dtype to use if undefined
         """
         dtype = self.dtypes[field] if field in self.dtypes else default_dtype
         try:
@@ -411,8 +411,6 @@ class NACCValidator(Validator):
         except (ValueError, TypeError, parser.ParserError) as error:
             self._error(field, error_def, str(error))
             return None
-
-        return None
 
     def _format_min_max(self, target_value: object, field: str, value: object,
                         error_def: ErrorDefs) -> Tuple[object, object]:
@@ -461,7 +459,7 @@ class NACCValidator(Validator):
             {'nullable': False}
         """
         if max_value in (SchemaDefs.CRR_DATE, SchemaDefs.CRR_YEAR):
-            dtype = 'int' if max_value == SchemaDefs.CRR_YEAR else 'date'
+            dtype = 'int' if max_value == SchemaDefs.CRR_YEAR else 'str'
             input_date = self._convert_value_to_date(
                 max_value,
                 field,
@@ -498,7 +496,7 @@ class NACCValidator(Validator):
         """
 
         if min_value in (SchemaDefs.CRR_DATE, SchemaDefs.CRR_YEAR):
-            dtype = 'int' if min_value == SchemaDefs.CRR_YEAR else 'date'
+            dtype = 'int' if min_value == SchemaDefs.CRR_YEAR else 'str'
             input_date = self._convert_value_to_date(
                 min_value,
                 field,

--- a/nacc_form_validator/utils.py
+++ b/nacc_form_validator/utils.py
@@ -86,6 +86,9 @@ def compare_values(comparator: str, value: Any, base_value: Any) -> bool:
     # for >= and <=, allow equality case (both None)
     if value is None and base_value is None:
         return True if comparator in ["<=", "==", ">="] else False
+    # if only one is None, return True for !=
+    if ((value is None) != (base_value is None)) and comparator == "!=":
+        return True
     if value is None:
         return True if comparator in ["<", "<="] else False
     if base_value is None:

--- a/tests/test_nacc_validator_datastore.py
+++ b/tests/test_nacc_validator_datastore.py
@@ -90,10 +90,7 @@ class CustomDatastore(Datastore):
         return sorted_record[index - 1] if index != 0 else None  # type: ignore
 
     def get_initial_record(
-        self,
-        current_record: Dict[str, Any],
-        ignore_empty_fields: Optional[List[str]] = None
-    ) -> Optional[Dict[str, Any]]:
+            self, current_record: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Grabs the initial record."""
         key = current_record[self.pk_field]
         if key not in self.__db:
@@ -101,6 +98,12 @@ class CustomDatastore(Datastore):
 
         if self.__db.get(key, None):
             return self.__db[key][0]  # type: ignore
+
+        return None
+
+    def get_uds_ivp_record(
+            self, current_record: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Grabs the UDS IVP record."""
 
         return None
 


### PR DESCRIPTION
* Revise `get_initial_record` method
  * remove ignore_empty checks
  * return first record for modules that don't have single IVP restriction
* Add `get_uds_ivp_record` to pull the UDS IVP packet (added this hoping to use for NP checks but ended up implementing them as pre-processing checks, keeping the method in case we need it in future)
* Fixed datatype for `current_date`
* Fixed a bug in `compare_with` rule for `!=` operator