### PR TITLE
Copy field datatypes from parent schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Documentation of release versions of `nacc-form-validator`
 
+## 0.6.1
+
+* Copies missing datatypes to a subschema validator from the parent validator
+  
 ## 0.6.0
 
 * Adds abstract method for pulling UDS IVP packets to Datastore

--- a/nacc_form_validator/BUILD
+++ b/nacc_form_validator/BUILD
@@ -7,7 +7,7 @@ python_distribution(
     sdist=True,
     provides=python_artifact(
         name="nacc-form-validator",
-        version="0.6.0",
+        version="0.6.1",
         description="The NACC form validator package",
         author="NACC",
         author_email="nacchelp@uw.edu",

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -54,7 +54,7 @@ class NACCValidator(Validator):
 
         # Field datatypes extracted from parent schema
         # only applicable for a subschema validator
-        self.__parent_dtypes: Dict[str, str] = None
+        self.__parent_dtypes: Optional[Dict[str, str]] = None
 
     @property
     def dtypes(self) -> Dict[str, str]:

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -52,6 +52,10 @@ class NACCValidator(Validator):
         # List of system errors occured by field
         self.__sys_errors: Dict[str, List[str]] = {}
 
+        # Field datatypes extracted from parent schema
+        # only applicable for a subschema validator
+        self.__parent_dtypes: Dict[str, str] = None
+
     @property
     def dtypes(self) -> Dict[str, str]:
         """Returns the field->datatype mapping for the fields defined in the
@@ -149,6 +153,41 @@ class NACCValidator(Validator):
         """Clear the system errors."""
 
         self.__sys_errors.clear()
+
+    @property
+    def parent_dtypes(self) -> Optional[Dict[str, str]]:
+        """Returns the parent datatypes dict if present."""
+        return self.__parent_dtypes
+
+    @parent_dtypes.setter
+    def parent_dtypes(self, parent_dtypes: Dict[str, str]):
+        """Set the parent datatypes for a subschema validator.
+
+        Args:
+            parent_dtypes: Field datatypes from parent validator
+        """
+        self.__parent_dtypes = parent_dtypes
+
+    def _copy_datatypes(self):
+        """Copy any missing datatypes to a subschema from a parent schema.
+
+        If subschema already has a datatype set for the field, that type
+        is used.
+        """
+
+        if self.parent_dtypes is None:
+            return
+
+        for field in self.schema:
+            # Continue if datatype already set
+            if field in self.dtypes:
+                continue
+
+            datatype = self.parent_dtypes.get(field)
+            if datatype:
+                self.__dtypes[field] = datatype
+            else:
+                log.warning(f"Cannot find datatype for {field}")
 
     def reset_record_cache(self):
         """Clear the previous records cache."""
@@ -579,10 +618,16 @@ class NACCValidator(Validator):
                 error_handler=CustomErrorHandler(subschema),
             )
 
-            # pass the same datastore
-            if self.primary_key and self.datastore:
+            # pass the same primary key and datastore
+            if self.primary_key:
                 temp_validator.primary_key = self.primary_key
+            if self.datastore:
                 temp_validator.datastore = self.datastore
+
+            # copy datatypes from parent validator
+            temp_validator.parent_dtypes = (
+                self.parent_dtypes if self.parent_dtypes else self.dtypes)
+            temp_validator._copy_datatypes()
 
             if operator == "OR":
                 valid = valid or temp_validator.validate(record,

--- a/tests/test_nacc_validator.py
+++ b/tests/test_nacc_validator.py
@@ -1,7 +1,7 @@
 """Tests general NACCValidator (from nacc_validator.py) methods."""
 
-import pytest
 from dateutil import parser
+import pytest
 
 from nacc_form_validator.nacc_validator import ValidationException
 

--- a/tests/test_nacc_validator.py
+++ b/tests/test_nacc_validator.py
@@ -1,7 +1,6 @@
 """Tests general NACCValidator (from nacc_validator.py) methods."""
-
-from dateutil import parser
 import pytest
+from dateutil import parser
 
 from nacc_form_validator.nacc_validator import ValidationException
 

--- a/tests/test_nacc_validator_datastore.py
+++ b/tests/test_nacc_validator_datastore.py
@@ -1,8 +1,8 @@
 """Tests the NACCValidator (from nacc_validator.py) when a datastore is
 required, e.g. temporal rules Creates a dummy datastore for simple testing."""
-
 import copy
 from typing import Any, Dict, List, Optional
+
 import pytest
 
 from nacc_form_validator.datastore import Datastore

--- a/tests/test_nacc_validator_datastore.py
+++ b/tests/test_nacc_validator_datastore.py
@@ -44,7 +44,7 @@ class CustomDatastore(Datastore):
         super().__init__(pk_field, orderby)
 
     def get_previous_record(
-            self, current_record: Dict[str, str]) -> Optional[Dict[str, str]]:
+            self, current_record: Dict[str, Any]) -> Optional[Dict[str, str]]:
         """See where current record would fit in the sorted record and return
         the previous record.
 
@@ -65,7 +65,7 @@ class CustomDatastore(Datastore):
         return sorted_record[index - 1] if index != 0 else None  # type: ignore
 
     def get_previous_nonempty_record(
-            self, current_record: Dict[str, str],
+            self, current_record: Dict[str, Any],
             ignore_empty_fields: List[str]) -> Optional[Dict[str, str]]:
         """Grabs the previous record where field is not empty."""
         key = current_record[self.pk_field]

--- a/tests/test_nacc_validator_datastore.py
+++ b/tests/test_nacc_validator_datastore.py
@@ -3,7 +3,6 @@ required, e.g. temporal rules Creates a dummy datastore for simple testing."""
 
 import copy
 from typing import Any, Dict, List, Optional
-
 import pytest
 
 from nacc_form_validator.datastore import Datastore
@@ -21,14 +20,14 @@ class CustomDatastore(Datastore):
                 {
                     "visit_num": 1,
                     "taxes": 8,
-                    "birthyr": 1950,
+                    "birthyr": "1950",
                     "birthmo": None,
                     "birthdy": 27,
                 },
                 {
                     "visit_num": 3,
                     "taxes": 0,
-                    "birthyr": 1950,
+                    "birthyr": "1950",
                     "birthmo": 6,
                     "birthdy": 9,
                 },
@@ -714,3 +713,76 @@ def test_temporal_check_current_year():
             'temporal rule no: 0'
         ]
     }
+
+
+def test_nested_compatibility_temporal_compare_with():
+    """Test compare_with previous record nested in compatiblity."""
+    schema = {
+        "patient_id": {
+            "type": "string"
+        },
+        "visit_num": {
+            "type": "integer"
+        },
+        "birthyr": {
+            "type":
+            "integer",
+            "nullable":
+            True,
+            "compatibility": [{
+                "index": 0,
+                "if": {
+                    "birthyr": {
+                        "min": 1000,
+                        "max": 2025
+                    }
+                },
+                "then": {
+                    "birthyr": {
+                        "temporalrules": [{
+                            "index": 0,
+                            "previous": {
+                                "birthyr": {
+                                    "min": 1000,
+                                    "max": 2025
+                                }
+                            },
+                            "current": {
+                                "birthyr": {
+                                    "compare_with": {
+                                        "comparator": ">=",
+                                        "base": "birthyr",
+                                        "previous_record": True
+                                    }
+                                }
+                            }
+                        }]
+                    }
+                }
+            }]
+        }
+    }
+
+    nv = create_nacc_validator_with_ds(schema, "patient_id", "visit_num")
+    record = nv.cast_record({
+        "patient_id": "PatientID1",
+        "visit_num": 4,
+        "birthyr": 1950
+    })
+    print(f"\nErrors: {nv.errors}")
+    assert nv.validate(record)
+
+    record2 = nv.cast_record({
+        "patient_id": "PatientID1",
+        "visit_num": 4,
+        "birthyr": 1980
+    })
+    assert nv.validate(record2)
+
+    record3 = nv.cast_record({
+        "patient_id": "PatientID1",
+        "visit_num": 4,
+        "birthyr": 1940
+    })
+    # print(f"\nErrors: {nv.errors}")
+    assert not nv.validate(record3)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,6 @@
 """Tests the util methods in `utils.py`."""
-
-from dateutil import parser
 import pytest
+from dateutil import parser
 
 from nacc_form_validator.utils import (
     compare_values,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 """Tests the util methods in `utils.py`."""
 
-import pytest
 from dateutil import parser
+import pytest
 
 from nacc_form_validator.utils import (
     compare_values,


### PR DESCRIPTION
When creating a subschema validator to check nested rules, copy any missing datatypes from the parent schema