### PR TITLE
Support base_decimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Documentation of release versions of `nacc-form-validator`
 
+## 0.6.2
+
+* Adds `base_decimal` argument to `compare_with` to handle cases where a value is actually split between the int and a decimal variable that need to be combined
+
 ## 0.6.1
 
 * Copies missing datatypes to a subschema validator from the parent validator

--- a/docs/data-quality-rule-definition-guidelines.md
+++ b/docs/data-quality-rule-definition-guidelines.md
@@ -255,6 +255,8 @@ Used to validate the field based on comparison with another field, with optional
 
 * `comparator`: The comparison expression; can be one of `[">", "<", ">=", "<=", "==", "!="]`
 * `base`: The field or value to compare to
+* `base_decimal`: The decimal field or value to add to the base
+    * This is divided by ten before being added, e.g. if `base` is 5 and `base_decimal` is 8, full value becomes 5.8; similarly, if `base_decimal` is 0.8 then the full value becomes 5.08
 * `adjustment`: The adjustment to make to the base expression, if any. If specified, `op` must also be provided 
 * `op`: The operation to make the adjustment for; can be one of `["+", "-", "*", "/", "abs"]`. If specified, `adjustment` must also be provided
     * Follows the formula `field {comparator} base {op} adjustment`, e.g. `field <= base + adjustment`
@@ -282,6 +284,7 @@ The rule definition for `compare_with` should follow the following format:
         "compare_with": {
             "comparator": "comparator, one of >, <, >=, <=, ==, !=",
             "base": "field or value to compare field_name to",
+            "base_decimal": "decimal field or value to add to base",
             "adjustment": "(optional) the adjustment field or value",
             "op": "(optional) operation, one of +, -, *, /, abs",
             "previous_record": "(optional) boolean, whether or not to compare to base in the previous record",

--- a/nacc_form_validator/BUILD
+++ b/nacc_form_validator/BUILD
@@ -7,7 +7,7 @@ python_distribution(
     sdist=True,
     provides=python_artifact(
         name="nacc-form-validator",
-        version="0.6.1",
+        version="0.6.2",
         description="The NACC form validator package",
         author="NACC",
         author_email="nacchelp@uw.edu",

--- a/nacc_form_validator/keys.py
+++ b/nacc_form_validator/keys.py
@@ -30,6 +30,7 @@ class SchemaDefs:
     FORMATTING = "formatting"
     COMPARATOR = "comparator"
     BASE = "base"
+    BASE_DECIMAL = "base_decimal"
     ADJUST = "adjustment"
     IGNORE_EMPTY = "ignore_empty"
     BIRTH_MONTH = "birth_month"

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -1063,6 +1063,11 @@ class NACCValidator(Validator):
                         'required': True,
                         'empty': False
                     },
+                    'base_decimal': {
+                        'type': ['string', 'number'],
+                        'required': False,
+                        'empty': False
+                    },
                     'adjustment': {
                         'type': ['string', 'number'],
                         'required': False,
@@ -1095,6 +1100,7 @@ class NACCValidator(Validator):
 
         comparator = comparison[SchemaDefs.COMPARATOR]
         base = comparison[SchemaDefs.BASE]
+        base_decimal = comparison.get(SchemaDefs.BASE_DECIMAL)
         adjustment = comparison.get(SchemaDefs.ADJUST, None)
         operator = comparison.get(SchemaDefs.OP, None)
 
@@ -1138,14 +1144,19 @@ class NACCValidator(Validator):
                 record = self.__get_initial_record(field=base)
 
             base_val = record[base] if record else None
+            base_decimal_value = record.get(base_decimal) if record else None
         else:
             base_val = self.__get_value_for_key(base)
+            base_decimal_value = self.__get_value_for_key(base_decimal)
 
         if base_val is None:
             error = (ErrorDefs.COMPARE_WITH_PREV
                      if prev_record else ErrorDefs.COMPARE_WITH)
             self._error(field, error, comparison_str, visit_type)
             return
+
+        if base_decimal_value:
+            base_val += (base_decimal_value / 10.0)
 
         try:
             adjusted_value = base_val
@@ -1401,3 +1412,5 @@ class NACCValidator(Validator):
         if errors:
             for error in errors.items():
                 self._error(field, ErrorDefs.SCORING_INVALID, value)
+
+

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -1414,5 +1414,3 @@ class NACCValidator(Validator):
         if errors:
             for error in errors.items():
                 self._error(field, ErrorDefs.SCORING_INVALID, value)
-
-

--- a/nacc_form_validator/nacc_validator.py
+++ b/nacc_form_validator/nacc_validator.py
@@ -1144,10 +1144,12 @@ class NACCValidator(Validator):
                 record = self.__get_initial_record(field=base)
 
             base_val = record[base] if record else None
-            base_decimal_value = record.get(base_decimal) if record else None
+            base_decimal_value = record.get(base_decimal) \
+                if record and base_decimal else None
         else:
             base_val = self.__get_value_for_key(base)
-            base_decimal_value = self.__get_value_for_key(base_decimal)
+            base_decimal_value = self.__get_value_for_key(base_decimal) \
+                if base_decimal else None
 
         if base_val is None:
             error = (ErrorDefs.COMPARE_WITH_PREV

--- a/tests/test_rules_compare_with.py
+++ b/tests/test_rules_compare_with.py
@@ -195,19 +195,31 @@ def test_compare_with_base_decimal(create_nacc_validator):
     nv = create_nacc_validator(schema)
 
     # 65.6 - 60.9 = 4.6 so should pass
-    assert nv.validate({"new_height": 65.5, "prev_height": 60, "prev_heigdec": 9})
+    assert nv.validate({
+        "new_height": 65.5,
+        "prev_height": 60,
+        "prev_heigdec": 9
+    })
 
     # 60.0 - 65.9 = -5.9 so should fail
-    assert not nv.validate({"new_height": 60, "prev_height": 65, "prev_heigdec": 9})
+    assert not nv.validate({
+        "new_height": 60,
+        "prev_height": 65,
+        "prev_heigdec": 9
+    })
     assert nv.errors == {
         "new_height": [
-            "input value doesn't satisfy the condition "
-            + "abs(new_height - prev_height) <= 5"
+            "input value doesn't satisfy the condition " +
+            "abs(new_height - prev_height) <= 5"
         ]
     }
 
     # sanity check prev_heigdec = 0 doesn't crash the code
-    assert nv.validate({"new_height": 65.5, "prev_height": 65, "prev_heigdec": 0})
+    assert nv.validate({
+        "new_height": 65.5,
+        "prev_height": 65,
+        "prev_heigdec": 0
+    })
 
     # test the "old" behavior without the decimal works as expected,
     # e.g. get opposite result
@@ -218,8 +230,8 @@ def test_compare_with_base_decimal(create_nacc_validator):
     assert not nv.validate({"new_height": 65.5, "prev_height": 60})
     assert nv.errors == {
         "new_height": [
-            "input value doesn't satisfy the condition "
-            + "abs(new_height - prev_height) <= 5"
+            "input value doesn't satisfy the condition " +
+            "abs(new_height - prev_height) <= 5"
         ]
     }
 

--- a/tests/test_rules_compare_with.py
+++ b/tests/test_rules_compare_with.py
@@ -168,3 +168,54 @@ def test_compare_with_absolute_value(create_nacc_validator):
             "input value doesn't satisfy the condition abs(waist1 - waist2) <= 0.5"
         ]
     }
+
+
+def test_compare_with_base_decimal(create_nacc_validator):
+    """Test compare_with when base_decimal is specified."""
+    schema = {
+        "new_height": {
+            "type": "float",
+            "required": True,
+            "compare_with": {
+                "comparator": "<=",
+                "base": "prev_height",
+                "base_decimal": "prev_heigdec",
+                "op": "abs",
+                "adjustment": 5
+            },
+        },
+        "prev_height": {
+            "type": "float"
+        },
+        "prev_heigdec": {
+            "type": "float",
+            "nullable": True
+        }
+    }
+    nv = create_nacc_validator(schema)
+
+    # 65.6 - 60.9 = 4.6 so should pass
+    assert nv.validate({"new_height": 65.5, "prev_height": 60, "prev_heigdec": 9})
+
+    # 60.0 - 65.9 = -5.9 so should fail
+    assert not nv.validate({"new_height": 60, "prev_height": 65, "prev_heigdec": 9})
+    assert nv.errors == {
+        "new_height": [
+            "input value doesn't satisfy the condition abs(new_height - prev_height) <= 5"
+        ]
+    }
+
+    # test the "old" behavior without the decimal works as expected, e.g. get opposite result
+    schema['new_height']['compare_with'].pop('base_decimal')
+    nv = create_nacc_validator(schema)
+
+    # 65.5 - 60 = 5.5 which fails
+    assert not nv.validate({"new_height": 65.5, "prev_height": 60})
+    assert nv.errors == {
+        "new_height": [
+            "input value doesn't satisfy the condition abs(new_height - prev_height) <= 5"
+        ]
+    }
+
+    # 60.0 - 65 = -5 which passes
+    assert nv.validate({"new_height": 60, "prev_height": 65})

--- a/tests/test_rules_compare_with.py
+++ b/tests/test_rules_compare_with.py
@@ -205,6 +205,9 @@ def test_compare_with_base_decimal(create_nacc_validator):
         ]
     }
 
+    # sanity check prev_heigdec = 0 doesn't crash the code
+    assert nv.validate({"new_height": 65.5, "prev_height": 65, "prev_heigdec": 0})
+
     # test the "old" behavior without the decimal works as expected, e.g. get opposite result
     schema['new_height']['compare_with'].pop('base_decimal')
     nv = create_nacc_validator(schema)

--- a/tests/test_rules_compare_with.py
+++ b/tests/test_rules_compare_with.py
@@ -201,14 +201,16 @@ def test_compare_with_base_decimal(create_nacc_validator):
     assert not nv.validate({"new_height": 60, "prev_height": 65, "prev_heigdec": 9})
     assert nv.errors == {
         "new_height": [
-            "input value doesn't satisfy the condition abs(new_height - prev_height) <= 5"
+            "input value doesn't satisfy the condition "
+            + "abs(new_height - prev_height) <= 5"
         ]
     }
 
     # sanity check prev_heigdec = 0 doesn't crash the code
     assert nv.validate({"new_height": 65.5, "prev_height": 65, "prev_heigdec": 0})
 
-    # test the "old" behavior without the decimal works as expected, e.g. get opposite result
+    # test the "old" behavior without the decimal works as expected,
+    # e.g. get opposite result
     schema['new_height']['compare_with'].pop('base_decimal')
     nv = create_nacc_validator(schema)
 
@@ -216,7 +218,8 @@ def test_compare_with_base_decimal(create_nacc_validator):
     assert not nv.validate({"new_height": 65.5, "prev_height": 60})
     assert nv.errors == {
         "new_height": [
-            "input value doesn't satisfy the condition abs(new_height - prev_height) <= 5"
+            "input value doesn't satisfy the condition "
+            + "abs(new_height - prev_height) <= 5"
         ]
     }
 


### PR DESCRIPTION
Handles the HEIGDEC issue by adding the `base_decimal` argument to the `compare_with` rule. 

This was the "cleanest/easiest" solution I could come up with, but open to other ideas.